### PR TITLE
refactor: BaseEntity 상속

### DIFF
--- a/src/main/java/com/shy_polarbear/server/domain/comment/entity/Comment.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/entity/Comment.java
@@ -2,6 +2,7 @@ package com.shy_polarbear.server.domain.comment.entity;
 
 import com.shy_polarbear.server.domain.feed.entity.Feed;
 import com.shy_polarbear.server.domain.user.entity.User;
+import com.shy_polarbear.server.global.common.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +15,7 @@ import java.util.List;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Comment {
+public class Comment extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/shy_polarbear/server/domain/comment/entity/CommentLike.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/entity/CommentLike.java
@@ -1,6 +1,7 @@
 package com.shy_polarbear.server.domain.comment.entity;
 
 import com.shy_polarbear.server.domain.user.entity.User;
+import com.shy_polarbear.server.global.common.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +12,7 @@ import javax.persistence.*;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class CommentLike {
+public class CommentLike extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/src/main/java/com/shy_polarbear/server/domain/feed/entity/Feed.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/entity/Feed.java
@@ -1,6 +1,7 @@
 package com.shy_polarbear.server.domain.feed.entity;
 
 import com.shy_polarbear.server.domain.user.entity.User;
+import com.shy_polarbear.server.global.common.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,7 +13,7 @@ import java.util.List;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Feed {
+public class Feed extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/shy_polarbear/server/domain/point/entity/Point.java
+++ b/src/main/java/com/shy_polarbear/server/domain/point/entity/Point.java
@@ -2,6 +2,7 @@ package com.shy_polarbear.server.domain.point.entity;
 
 import com.shy_polarbear.server.domain.ranking.entity.Ranking;
 import com.shy_polarbear.server.domain.user.entity.User;
+import com.shy_polarbear.server.global.common.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,7 +13,7 @@ import javax.persistence.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Point {
+public class Point extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/entity/Quiz.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/entity/Quiz.java
@@ -1,5 +1,6 @@
 package com.shy_polarbear.server.domain.quiz.entity;
 
+import com.shy_polarbear.server.global.common.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,7 +11,7 @@ import javax.persistence.*;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Quiz {
+public class Quiz extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "quiz_id")

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/entity/UserQuiz.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/entity/UserQuiz.java
@@ -1,6 +1,7 @@
 package com.shy_polarbear.server.domain.quiz.entity;
 
 import com.shy_polarbear.server.domain.user.entity.User;
+import com.shy_polarbear.server.global.common.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +12,7 @@ import javax.persistence.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UserQuiz {
+public class UserQuiz extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/shy_polarbear/server/domain/user/entity/User.java
+++ b/src/main/java/com/shy_polarbear/server/domain/user/entity/User.java
@@ -4,6 +4,7 @@ package com.shy_polarbear.server.domain.user.entity;
 import com.shy_polarbear.server.domain.quiz.entity.UserQuiz;
 import com.shy_polarbear.server.domain.point.entity.Point;
 import com.shy_polarbear.server.domain.ranking.entity.Ranking;
+import com.shy_polarbear.server.global.common.BaseEntity;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 
@@ -16,7 +17,7 @@ import java.util.List;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicInsert
-public class User {
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/shy_polarbear/server/domain/user/entity/WithdrawnUser.java
+++ b/src/main/java/com/shy_polarbear/server/domain/user/entity/WithdrawnUser.java
@@ -1,5 +1,6 @@
 package com.shy_polarbear.server.domain.user.entity;
 
+import com.shy_polarbear.server.global.common.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,12 +11,11 @@ import java.time.LocalDateTime;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class WithdrawnUser {
+public class WithdrawnUser extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "withdrawn_user_id")
     private Long id;
-    private LocalDateTime withdrawalTime;
     private Long userId;
 }


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- BaseEntity 상속

🌱 PR 포인트
- 나중에 생성일자, 변경일자가 필요해질 수 있는 엔티티들은 모두 BaseEntity를 상속받게 했습니다.
- WithdrawnUser는  BaseEntity를 상속받았기 때문에 withdrawalTime 필드를 삭제했습니다.  
