### PR TITLE
Feature/set test user

### DIFF
--- a/src/main/java/com/shy_polarbear/server/domain/user/controller/AuthController.java
+++ b/src/main/java/com/shy_polarbear/server/domain/user/controller/AuthController.java
@@ -1,7 +1,7 @@
 package com.shy_polarbear.server.domain.user.controller;
 
 import com.shy_polarbear.server.global.common.dto.ApiResponse;
-import com.shy_polarbear.server.global.config.jwt.JwtDto;
+import com.shy_polarbear.server.global.auth.jwt.JwtDto;
 import com.shy_polarbear.server.domain.user.dto.*;
 import com.shy_polarbear.server.domain.user.dto.JoinRequest;
 import com.shy_polarbear.server.domain.user.dto.SocialLoginRequest;

--- a/src/main/java/com/shy_polarbear/server/domain/user/service/AuthService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/user/service/AuthService.java
@@ -1,14 +1,14 @@
 package com.shy_polarbear.server.domain.user.service;
 
-import com.shy_polarbear.server.global.config.jwt.JwtDto;
-import com.shy_polarbear.server.global.config.jwt.RefreshToken;
-import com.shy_polarbear.server.global.config.jwt.RefreshTokenRepository;
-import com.shy_polarbear.server.global.config.security.PrincipalDetails;
+import com.shy_polarbear.server.global.auth.jwt.JwtDto;
+import com.shy_polarbear.server.global.auth.jwt.RefreshToken;
+import com.shy_polarbear.server.global.auth.jwt.RefreshTokenRepository;
+import com.shy_polarbear.server.global.auth.security.PrincipalDetails;
 import com.shy_polarbear.server.domain.user.dto.*;
 import com.shy_polarbear.server.domain.user.dto.JoinRequest;
 import com.shy_polarbear.server.domain.user.dto.SocialLoginRequest;
 import com.shy_polarbear.server.domain.user.exception.AuthException;
-import com.shy_polarbear.server.global.config.jwt.JwtProvider;
+import com.shy_polarbear.server.global.auth.jwt.JwtProvider;
 import com.shy_polarbear.server.domain.user.exception.UserException;
 import com.shy_polarbear.server.domain.user.model.User;
 import com.shy_polarbear.server.domain.user.model.UserRole;
@@ -73,7 +73,7 @@ public class AuthService {
         return issuedToken;
     }
 
-    private JwtDto authorizeUser(String providerId) {
+    public JwtDto authorizeUser(String providerId) {
         Authentication authentication = new UsernamePasswordAuthenticationToken(providerId, providerId +"@password");
         Authentication authenticated  = authenticationManager.authenticate(authentication);
         SecurityContextHolder.getContext().setAuthentication(authenticated);

--- a/src/main/java/com/shy_polarbear/server/domain/user/service/AuthService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/user/service/AuthService.java
@@ -72,8 +72,7 @@ public class AuthService {
         JwtDto issuedToken = authorizeUser(providerId);
         return issuedToken;
     }
-
-    public JwtDto authorizeUser(String providerId) {
+    private JwtDto authorizeUser(String providerId) {
         Authentication authentication = new UsernamePasswordAuthenticationToken(providerId, providerId +"@password");
         Authentication authenticated  = authenticationManager.authenticate(authentication);
         SecurityContextHolder.getContext().setAuthentication(authenticated);

--- a/src/main/java/com/shy_polarbear/server/global/auth/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/shy_polarbear/server/global/auth/jwt/JwtAuthenticationEntryPoint.java
@@ -1,4 +1,4 @@
-package com.shy_polarbear.server.global.config.jwt;
+package com.shy_polarbear.server.global.auth.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.shy_polarbear.server.global.common.dto.ApiResponse;

--- a/src/main/java/com/shy_polarbear/server/global/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/shy_polarbear/server/global/auth/jwt/JwtAuthenticationFilter.java
@@ -1,4 +1,4 @@
-package com.shy_polarbear.server.global.config.jwt;
+package com.shy_polarbear.server.global.auth.jwt;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/com/shy_polarbear/server/global/auth/jwt/JwtDto.java
+++ b/src/main/java/com/shy_polarbear/server/global/auth/jwt/JwtDto.java
@@ -1,4 +1,4 @@
-package com.shy_polarbear.server.global.config.jwt;
+package com.shy_polarbear.server.global.auth.jwt;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/shy_polarbear/server/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/shy_polarbear/server/global/auth/jwt/JwtProvider.java
@@ -1,7 +1,7 @@
-package com.shy_polarbear.server.global.config.jwt;
+package com.shy_polarbear.server.global.auth.jwt;
 
 
-import com.shy_polarbear.server.global.config.security.PrincipalDetailService;
+import com.shy_polarbear.server.global.auth.security.PrincipalDetailService;
 import com.shy_polarbear.server.domain.user.exception.AuthException;
 import com.shy_polarbear.server.domain.user.model.User;
 import com.shy_polarbear.server.global.exception.ExceptionStatus;
@@ -55,7 +55,7 @@ public class JwtProvider {
     public String createAccessToken(User user) {
         Date now = new Date(System.currentTimeMillis());
         return Jwts.builder()
-                .setSubject(user.getProviderId().toString())
+                .setSubject(user.getProviderId())
                 .setIssuedAt(now)
                 .claim("tokenType", "access")
                 .setExpiration(new Date(now.getTime() + accessTokenValidTime))
@@ -67,7 +67,7 @@ public class JwtProvider {
     public String createRefreshToken(User user) {
         Date now = new Date(System.currentTimeMillis());
         return Jwts.builder()
-                .setSubject(user.getProviderId().toString())
+                .setSubject(user.getProviderId())
                 .setIssuedAt(now)
                 .claim("tokenType", "refresh")
                 .setExpiration(new Date(now.getTime() + refreshTokenValidTime))

--- a/src/main/java/com/shy_polarbear/server/global/auth/jwt/JwtSecurityConfig.java
+++ b/src/main/java/com/shy_polarbear/server/global/auth/jwt/JwtSecurityConfig.java
@@ -1,4 +1,4 @@
-package com.shy_polarbear.server.global.config.jwt;
+package com.shy_polarbear.server.global.auth.jwt;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter;

--- a/src/main/java/com/shy_polarbear/server/global/auth/jwt/RefreshToken.java
+++ b/src/main/java/com/shy_polarbear/server/global/auth/jwt/RefreshToken.java
@@ -1,4 +1,4 @@
-package com.shy_polarbear.server.global.config.jwt;
+package com.shy_polarbear.server.global.auth.jwt;
 
 import com.shy_polarbear.server.domain.user.model.User;
 import lombok.AccessLevel;

--- a/src/main/java/com/shy_polarbear/server/global/auth/jwt/RefreshTokenRepository.java
+++ b/src/main/java/com/shy_polarbear/server/global/auth/jwt/RefreshTokenRepository.java
@@ -1,4 +1,4 @@
-package com.shy_polarbear.server.global.config.jwt;
+package com.shy_polarbear.server.global.auth.jwt;
 
 import com.shy_polarbear.server.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/shy_polarbear/server/global/auth/security/PrincipalDetailService.java
+++ b/src/main/java/com/shy_polarbear/server/global/auth/security/PrincipalDetailService.java
@@ -1,4 +1,4 @@
-package com.shy_polarbear.server.global.config.security;
+package com.shy_polarbear.server.global.auth.security;
 
 import com.shy_polarbear.server.domain.user.model.User;
 import com.shy_polarbear.server.domain.user.repository.UserRepository;

--- a/src/main/java/com/shy_polarbear/server/global/auth/security/PrincipalDetails.java
+++ b/src/main/java/com/shy_polarbear/server/global/auth/security/PrincipalDetails.java
@@ -1,4 +1,4 @@
-package com.shy_polarbear.server.global.config.security;
+package com.shy_polarbear.server.global.auth.security;
 
 import com.shy_polarbear.server.domain.user.model.User;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/shy_polarbear/server/global/auth/security/SecurityConfig.java
+++ b/src/main/java/com/shy_polarbear/server/global/auth/security/SecurityConfig.java
@@ -1,10 +1,10 @@
-package com.shy_polarbear.server.global.config.security;
+package com.shy_polarbear.server.global.auth.security;
 
 
 
-import com.shy_polarbear.server.global.config.jwt.JwtAuthenticationEntryPoint;
-import com.shy_polarbear.server.global.config.jwt.JwtAuthenticationFilter;
-import com.shy_polarbear.server.global.config.jwt.JwtProvider;
+import com.shy_polarbear.server.global.auth.jwt.JwtProvider;
+import com.shy_polarbear.server.global.auth.jwt.JwtAuthenticationEntryPoint;
+import com.shy_polarbear.server.global.auth.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/shy_polarbear/server/global/common/dto/ApiResponse.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/dto/ApiResponse.java
@@ -14,11 +14,6 @@ public class ApiResponse<T> {
     private T data;
     private String message;
 
-    private ApiResponse(T data) {
-        this.code = null;
-        this.data = data;
-    }
-
     private ApiResponse(int code, T data, String message) {
         this.code = code;
         this.data = data;
@@ -26,7 +21,7 @@ public class ApiResponse<T> {
     }
 
     public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(data);
+        return new ApiResponse<>(0, data, "");
     }
 
     public static ApiResponse error(int code, String message) {

--- a/src/main/java/com/shy_polarbear/server/global/common/dummy/LoginUserInitializer.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/dummy/LoginUserInitializer.java
@@ -1,0 +1,52 @@
+package com.shy_polarbear.server.global.common.dummy;
+
+import com.shy_polarbear.server.domain.user.model.User;
+import com.shy_polarbear.server.domain.user.model.UserRole;
+import com.shy_polarbear.server.domain.user.repository.UserRepository;
+import com.shy_polarbear.server.domain.user.service.ProviderType;
+import com.shy_polarbear.server.global.auth.jwt.JwtDto;
+import com.shy_polarbear.server.global.auth.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.transaction.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LoginUserInitializer {
+
+    private User user;
+    private String nickName = "노을";
+    private String email = "chi6465618@naver.com";
+    private String profileImage = "";
+    private String phoneNumber = "01093926465";
+    private UserRole userRole = UserRole.ROLE_USR;
+    private String providerId = "0000";
+    private ProviderType provider = ProviderType.KAKAO;
+    private final PasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+
+
+    @PostConstruct
+    public void init() {
+        createDummyUser();
+    }
+
+    @Transactional
+    void createDummyUser() {
+        if (userRepository.count() > 0) {
+            log.info("어드민, 유저가 이미 존재하여 더미를 생성하지 않았습니다.");
+            return;
+        }
+        user = User.createUser(nickName, email, profileImage, phoneNumber, userRole, providerId, provider.getValue(), passwordEncoder);
+        userRepository.save(user);
+        JwtDto issue = jwtProvider.issue(user);
+        log.info("테스트 유저 access token : {}", issue.getAccessToken());
+    }
+}
+

--- a/src/test/java/com/shy_polarbear/server/domain/config/jwt/JwtProviderTest.java
+++ b/src/test/java/com/shy_polarbear/server/domain/config/jwt/JwtProviderTest.java
@@ -4,7 +4,7 @@ package com.shy_polarbear.server.domain.config.jwt;
 import com.shy_polarbear.server.domain.user.model.User;
 import com.shy_polarbear.server.domain.user.model.UserRole;
 import com.shy_polarbear.server.domain.user.repository.UserRepository;
-import com.shy_polarbear.server.global.config.jwt.JwtProvider;
+import com.shy_polarbear.server.global.auth.jwt.JwtProvider;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- jwt, security 패키지 이동
- 성공 코드, 성공 메세지 추가
- 더미 유저 추가

🌱 PR 포인트
- jwt, security 패키지를 `/global/config`에서 `/global/auth`로 이동시켰습니다.
-  ApiResponse에서 success() 메서드 실행 시 `code`는 `0`, `message`는 빈 값(`""`)으로 설정하게 했습니다.
- LoginUserInitializer 에서 `@PostConstruct`로 빈 생성 후 더미유저가 생성되게 했습니다. (유저를 DB에 저장 후 access token과 refersh token을 새로 발급)

## 📸 스크린샷
![image](https://github.com/ShyPolarBear/Server/assets/81086966/34354bdc-97f5-43d1-b9e5-8ec6e44eeac1)
유효기간이 긴 토큰을 발급하여 db에 저장하려고 했지만 
1. 로그아웃 시 새로 토큰을 새로 발급해서 refresh token 업데이트 해야 함.
2.  ddl auto 옵션 create 시 의미 없어짐.
3.   노션이나 잔디에서 access token을 복사해야 함.

 과 같은 문제로 더미 유저 access token 값을 로그로 남겼습니다!!
(더 좋은 방법이 있을까요..?ㅜㅠ) 
