### PR TITLE
fix: 더미 유저가 있는 경우에도 토큰 재발급, 더미 피드 추가

### DIFF
--- a/src/main/java/com/shy_polarbear/server/global/common/dummy/FeedInitializer.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/dummy/FeedInitializer.java
@@ -1,0 +1,45 @@
+package com.shy_polarbear.server.global.common.dummy;
+
+import com.shy_polarbear.server.domain.feed.model.Feed;
+import com.shy_polarbear.server.domain.feed.repository.FeedRepository;
+import com.shy_polarbear.server.domain.user.exception.UserException;
+import com.shy_polarbear.server.domain.user.model.User;
+import com.shy_polarbear.server.domain.user.repository.UserRepository;
+import com.shy_polarbear.server.global.exception.ExceptionStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class FeedInitializer {
+
+    private final FeedRepository feedRepository;
+    private final UserRepository userRepository;
+
+    @PostConstruct
+    public void init() {
+        createDummyFeed();
+    }
+
+    @Transactional
+    void createDummyFeed() {
+        User user = userRepository.findByProviderId("0000")
+                .orElseThrow(() -> new UserException(ExceptionStatus.NOT_FOUND_USER));
+        if (feedRepository.count() == 0) {
+            log.info("더미 피드 10개를 생성합니다.");
+            for (int i = 0; i < 10; i++) {
+                List<String> feedImages = new ArrayList<>();
+                feedImages.add("테스트 사진");
+                Feed feed = Feed.createFeed("제목" + i, null, feedImages, user);
+                feedRepository.save(feed);
+            }
+        }
+    }
+}

--- a/src/main/java/com/shy_polarbear/server/global/common/dummy/LoginUserInitializer.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/dummy/LoginUserInitializer.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
 import javax.transaction.Transactional;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -39,14 +40,16 @@ public class LoginUserInitializer {
 
     @Transactional
     void createDummyUser() {
-        if (userRepository.count() > 0) {
-            log.info("어드민, 유저가 이미 존재하여 더미를 생성하지 않았습니다.");
-            return;
+        Optional<User> userAble = userRepository.findByProviderId(providerId);
+        if (userAble.isPresent()) {
+            user = userAble.get();
+            log.info("유저가 이미 존재하여 더미를 생성하지 않았습니다.");
+        } else {
+            user = User.createUser(nickName, email, profileImage, phoneNumber, userRole, providerId, provider.getValue(), passwordEncoder);
+            userRepository.save(user);
         }
-        user = User.createUser(nickName, email, profileImage, phoneNumber, userRole, providerId, provider.getValue(), passwordEncoder);
-        userRepository.save(user);
         JwtDto issue = jwtProvider.issue(user);
-        log.info("테스트 유저 access token : {}", issue.getAccessToken());
+        log.info("더미 유저 access token : {}", issue.getAccessToken());
     }
 }
 


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- ddl 옵션을 create로 해도 rds 서버에 더미 유저가 사라지지 않아, 서버를 띄울 때 마다 더미 유저가 추가되지 않는 문제가 발생했습니다.
- 더미 유저가 이미 존재하더라도 토큰을 발급하고   

🌱 PR 포인트
- ddl 옵션을 create로 해도 rds 서버에 더미 유저가 사라지지 않아, 서버를 띄울 때 마다 더미 유저가 추가되지 않는 문제가 발생했습니다.
- 그래서 더미 유저가 이미 존재하더라도 토큰을 발급하고 엑세스 토큰을 로그로 남겨 서버에 요청 시 사용할 수 있게 했습니다.
- DB에는 provider id가 0000인 더미 유저 하나가 생성됩니다.
- 추가로, 더미 유저가 작성한 더미 피드 10개를 넣어놨습니다. (DB에 저장되는 데이터는 아래 사진과 같습니다.)

![image](https://github.com/ShyPolarBear/Server/assets/81086966/738d22b5-86d2-40d8-904f-7dcd4dfdf910)

![image](https://github.com/ShyPolarBear/Server/assets/81086966/439c9744-1016-4158-85ba-012888087581)



