### PR TITLE
fix: PostConstruct 컴포넌트 순서 문제

### DIFF
--- a/src/main/java/com/shy_polarbear/server/global/common/dummy/FeedInitializer.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/dummy/FeedInitializer.java
@@ -8,6 +8,7 @@ import com.shy_polarbear.server.domain.user.repository.UserRepository;
 import com.shy_polarbear.server.global.exception.ExceptionStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
@@ -16,8 +17,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Component
+@DependsOn("LoginUserInitializer")
 @RequiredArgsConstructor
 @Slf4j
+@Transactional
 public class FeedInitializer {
 
     private final FeedRepository feedRepository;
@@ -28,8 +31,7 @@ public class FeedInitializer {
         createDummyFeed();
     }
 
-    @Transactional
-    void createDummyFeed() {
+    private void createDummyFeed() {
         User user = userRepository.findByProviderId("0000")
                 .orElseThrow(() -> new UserException(ExceptionStatus.NOT_FOUND_USER));
         if (feedRepository.count() == 0) {

--- a/src/main/java/com/shy_polarbear/server/global/common/dummy/LoginUserInitializer.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/dummy/LoginUserInitializer.java
@@ -15,9 +15,10 @@ import javax.annotation.PostConstruct;
 import javax.transaction.Transactional;
 import java.util.Optional;
 
-@Component
+@Component("LoginUserInitializer")
 @RequiredArgsConstructor
 @Slf4j
+@Transactional
 public class LoginUserInitializer {
 
     private User user;
@@ -38,8 +39,7 @@ public class LoginUserInitializer {
         createDummyUser();
     }
 
-    @Transactional
-    void createDummyUser() {
+    private void createDummyUser() {
         Optional<User> userAble = userRepository.findByProviderId(providerId);
         if (userAble.isPresent()) {
             user = userAble.get();


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용

Initializer Component 순서 설정

🌱 PR 포인트
제 경우엔 앱 시작시에 UserInitializer 전에 FeedInitializer부터 실행이 되더라구요

=> `Component` 의 이름을 정하고, `@DependsOn` 으로 의존할 컴포넌트 이름을 지정하는 식으로 순서를 지정했습니다

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|


![image](https://github.com/ShyPolarBear/Server/assets/72124326/50f954fa-1b85-4f50-a36f-d8f36e16abe3)

![image](https://github.com/ShyPolarBear/Server/assets/72124326/2af24e39-cb8c-4db5-9168-9dac9361c8c1)

## 📮 관련 이슈
- Resolved: #이슈번호
