### PR TITLE
feat: 초기 셋업

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 *.yml
 application.properties
+
+### just memo
+memo.md

--- a/src/main/java/com/shy_polarbear/server/domain/HealthCheckController.java
+++ b/src/main/java/com/shy_polarbear/server/domain/HealthCheckController.java
@@ -1,0 +1,14 @@
+package com.shy_polarbear.server.domain;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/health")
+public class HealthCheckController {
+    @GetMapping
+    public String healthCheck() {
+        return "OK";
+    }
+}

--- a/src/main/java/com/shy_polarbear/server/global/auth/security/SecurityConfig.java
+++ b/src/main/java/com/shy_polarbear/server/global/auth/security/SecurityConfig.java
@@ -5,6 +5,7 @@ package com.shy_polarbear.server.global.auth.security;
 import com.shy_polarbear.server.global.auth.jwt.JwtAuthenticationEntryPoint;
 import com.shy_polarbear.server.global.auth.jwt.JwtAuthenticationFilter;
 import com.shy_polarbear.server.global.auth.jwt.JwtProvider;
+import com.shy_polarbear.server.global.common.constants.GlobalConstants;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,11 +43,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                 .and()
                     .authorizeRequests()
-                        .antMatchers("/api/auth/join/**", "/api/auth/login/**", "/api/auth/reissue/**",
-                            "/api/user/duplicate-nickname",
-                            "/api/prize/**",
-                            "/api/quiz", "/api/quiz",
-                            "/api/auth/test").permitAll()
+                            .antMatchers(GlobalConstants.permittedUrls).permitAll()
                         .anyRequest().authenticated()
                 .and()
                     .logout()

--- a/src/main/java/com/shy_polarbear/server/global/common/constants/GlobalConstants.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/constants/GlobalConstants.java
@@ -1,0 +1,15 @@
+package com.shy_polarbear.server.global.common.constants;
+
+public class GlobalConstants {
+    public static final String[] permittedUrls = {
+            "/api/auth/join/**",
+            "/api/auth/login/**",
+            "/api/auth/reissue/**",
+            "/api/user/duplicate-nickname",
+            "/api/prize/**",
+            "/api/quiz", "/api/quiz",
+            "/api/auth/test",
+            "/api/health"
+    };
+
+}

--- a/src/main/java/com/shy_polarbear/server/global/common/dto/NoCountPageResponse.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/dto/NoCountPageResponse.java
@@ -1,0 +1,21 @@
+package com.shy_polarbear.server.global.common.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class NoCountPageResponse<T> {   // 무한 스크롤 && 총 개수가 필요없는 클라이언트에 대한 응답 DTO
+    boolean isLast;
+    List<T> content;
+
+    public static <T> NoCountPageResponse<T> of(Slice<T> slice) {  // 오직 Slice. 카운트 쿼리 최적화
+        return NoCountPageResponse.<T>builder()
+                .isLast(slice.isLast())
+                .content(slice.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/shy_polarbear/server/global/common/dto/PageResponse.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/dto/PageResponse.java
@@ -13,29 +13,29 @@ import java.util.List;
 @Builder
 @Getter
 public class PageResponse<T> {
-    Long totalElements;
-    boolean last;
+    Long totalCount;
+    boolean isLast;
     List<T> content;
 
     public static <T> PageResponse<T> of(Page<T> page) {
         return PageResponse.<T>builder()
-                .totalElements(page.getTotalElements())
-                .last(page.isLast())
+                .totalCount(page.getTotalElements())
+                .isLast(page.isLast())
                 .content(page.getContent())
                 .build();
     }
 
     public static <T> PageResponse<T> of(Slice<T> slice) {  // 클라이언트에서 totalElements 사용 안 하는 경우, 카운트 쿼리 최적화 가능
         return PageResponse.<T>builder()
-                .last(slice.isLast())
+                .isLast(slice.isLast())
                 .content(slice.getContent())
                 .build();
     }
 
     public static <T> PageResponse<T> of(Slice<T> slice, Long totalElements) {
         return PageResponse.<T>builder()
-                .totalElements(totalElements)
-                .last(slice.isLast())
+                .totalCount(totalElements)
+                .isLast(slice.isLast())
                 .content(slice.getContent())
                 .build();
     }
@@ -59,8 +59,8 @@ public class PageResponse<T> {
 
     public static <T, O> PageResponse<T> of(Page<O> origin, List<T> list) {
         return PageResponse.<T>builder()
-                .totalElements(origin.getTotalElements())
-                .last(origin.isLast())
+                .totalCount(origin.getTotalElements())
+                .isLast(origin.isLast())
                 .content(list)
                 .build();
     }

--- a/src/main/java/com/shy_polarbear/server/global/common/dto/PageResponse.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/dto/PageResponse.java
@@ -1,0 +1,67 @@
+package com.shy_polarbear.server.global.common.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Builder
+@Getter
+public class PageResponse<T> {
+    Long totalElements;
+    boolean last;
+    List<T> content;
+
+    public static <T> PageResponse<T> of(Page<T> page) {
+        return PageResponse.<T>builder()
+                .totalElements(page.getTotalElements())
+                .last(page.isLast())
+                .content(page.getContent())
+                .build();
+    }
+
+    public static <T> PageResponse<T> of(Slice<T> slice) {  // 클라이언트에서 totalElements 사용 안 하는 경우, 카운트 쿼리 최적화 가능
+        return PageResponse.<T>builder()
+                .last(slice.isLast())
+                .content(slice.getContent())
+                .build();
+    }
+
+    public static <T> PageResponse<T> of(Slice<T> slice, Long totalElements) {
+        return PageResponse.<T>builder()
+                .totalElements(totalElements)
+                .last(slice.isLast())
+                .content(slice.getContent())
+                .build();
+    }
+
+    // 리스트를 자체 페이지 처리
+    public static <T> PageResponse<T> of(Pageable pageable, List<T> list) {
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), list.size());
+        List<T> content = new ArrayList<>();
+
+        if (start > end) list.subList(end, list.size());
+        else content = list.subList(start, end);
+
+        Page<T> newPage = new PageImpl<>(
+                content,
+                pageable,
+                list.size()
+        );
+        return PageResponse.of(newPage);
+    }
+
+    public static <T, O> PageResponse<T> of(Page<O> origin, List<T> list) {
+        return PageResponse.<T>builder()
+                .totalElements(origin.getTotalElements())
+                .last(origin.isLast())
+                .content(list)
+                .build();
+    }
+}

--- a/src/main/java/com/shy_polarbear/server/global/common/dto/PageResponse.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/dto/PageResponse.java
@@ -3,65 +3,30 @@ package com.shy_polarbear.server.global.common.dto;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Builder
 @Getter
-public class PageResponse<T> {
-    Long totalCount;
+public class PageResponse<T> {  // 총 개수가 필요한 클라이언트에 대한 응답 DTO
+    long count;
     boolean isLast;
     List<T> content;
 
     public static <T> PageResponse<T> of(Page<T> page) {
         return PageResponse.<T>builder()
-                .totalCount(page.getTotalElements())
+                .count(page.getTotalElements())
                 .isLast(page.isLast())
                 .content(page.getContent())
                 .build();
     }
 
-    public static <T> PageResponse<T> of(Slice<T> slice) {  // 클라이언트에서 totalElements 사용 안 하는 경우, 카운트 쿼리 최적화 가능
+    public static <T> PageResponse<T> of(Slice<T> slice, long totalElements) {  // Slice + 카운트 쿼리
         return PageResponse.<T>builder()
+                .count(totalElements)
                 .isLast(slice.isLast())
                 .content(slice.getContent())
-                .build();
-    }
-
-    public static <T> PageResponse<T> of(Slice<T> slice, Long totalElements) {
-        return PageResponse.<T>builder()
-                .totalCount(totalElements)
-                .isLast(slice.isLast())
-                .content(slice.getContent())
-                .build();
-    }
-
-    // 리스트를 자체 페이지 처리
-    public static <T> PageResponse<T> of(Pageable pageable, List<T> list) {
-        int start = (int) pageable.getOffset();
-        int end = Math.min(start + pageable.getPageSize(), list.size());
-        List<T> content = new ArrayList<>();
-
-        if (start > end) list.subList(end, list.size());
-        else content = list.subList(start, end);
-
-        Page<T> newPage = new PageImpl<>(
-                content,
-                pageable,
-                list.size()
-        );
-        return PageResponse.of(newPage);
-    }
-
-    public static <T, O> PageResponse<T> of(Page<O> origin, List<T> list) {
-        return PageResponse.<T>builder()
-                .totalCount(origin.getTotalElements())
-                .isLast(origin.isLast())
-                .content(list)
                 .build();
     }
 }


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 헬스 체크 API : 서버가 정상 작동중인지 체크하는 용도입니다.
- SecurityConfig 인증 필요없는 URI 리스트 상수화
- PageResponse

🌱 PR 포인트
- @nine03 @EgongD @0sunset0 전체 조회 API 등에서 리스트(Page, Slice, List)를 응답하실 때 PageResponse 쓰시면 됩니다.
전체 응답 값은 `ApiResponse<PageResponse<FeedResponse>>` 이런식으로 될거예요
통일성 있고 편리해서 추천합니다!

- 앞으로 Security 로직(JWT 토큰 인증)을 타지 않을 URI들은 GlobalConstants.permittedUrls에 넣어주시면 됩니다.
SecurityConfig가 민감한 파일이어서 최대한 파일 변경 이력 없도록 하기 위해서 이렇게 리팩토링했습니다   

- 개인적으로 md에다 투두리스트를 적은 뒤에 작업해서 gitignore에 추가했습니다ㅎㅎ,,

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|

헬스 체크 API

![image](https://github.com/ShyPolarBear/Server/assets/72124326/a4aa6a1d-090a-4622-9e83-9ed3f26c348d)

## 📮 관련 이슈
- Resolved: #이슈번호
