### PR TITLE
fix: 프로필이미지 nullable로 변경

### DIFF
--- a/src/main/java/com/shy_polarbear/server/domain/feed/dto/response/FeedResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/dto/response/FeedResponse.java
@@ -26,12 +26,13 @@ public class FeedResponse {
     private Boolean isAuthor;
 
     public static FeedResponse from(Feed feed, boolean isLike, boolean isAuthor) {
+        String profileImage = feed.getAuthor().getProfileImage();
         return FeedResponse.builder()
                 .feedId(feed.getId())
                 .title(feed.getTitle())
                 .content(feed.getContent())
                 .author(feed.getAuthor().getNickName())
-                .authorProfileImage(feed.getAuthor().getProfileImage())
+                .authorProfileImage((profileImage == null) ? "" : profileImage)
                 .feedImages(feed.getFeedImageUrls())
                 .createdDate(feed.getCreatedDate())
                 .commentCount(feed.getComments().size())

--- a/src/main/java/com/shy_polarbear/server/domain/user/dto/auth/request/JoinRequest.java
+++ b/src/main/java/com/shy_polarbear/server/domain/user/dto/auth/request/JoinRequest.java
@@ -18,6 +18,5 @@ public class JoinRequest {
     private String phoneNumber;
     @NotBlank
     private String email;
-    @NotBlank
     private String profileImage;
 }

--- a/src/main/java/com/shy_polarbear/server/domain/user/dto/user/request/UpdateUserInfoRequest.java
+++ b/src/main/java/com/shy_polarbear/server/domain/user/dto/user/request/UpdateUserInfoRequest.java
@@ -12,7 +12,6 @@ import javax.validation.constraints.NotBlank;
 public class UpdateUserInfoRequest {
     @NotBlank
     private String nickName;
-    @NotBlank
     private String profileImage;
     @NotBlank
     private String email;

--- a/src/main/java/com/shy_polarbear/server/domain/user/dto/user/response/UpdateUserInfoResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/user/dto/user/response/UpdateUserInfoResponse.java
@@ -26,7 +26,7 @@ public class UpdateUserInfoResponse {
         return UpdateUserInfoResponse.builder()
                 .id(user.getId())
                 .nickName(user.getEmail())
-                .profileImage(user.getProfileImage())
+                .profileImage(user.getProfileImage() == null ? "" : user.getProfileImage())
                 .email(user.getEmail())
                 .phoneNumber(user.getPhoneNumber())
                 .build();

--- a/src/main/java/com/shy_polarbear/server/domain/user/dto/user/response/UserCommentFeedsResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/user/dto/user/response/UserCommentFeedsResponse.java
@@ -30,7 +30,8 @@ public class UserCommentFeedsResponse {
             Long feedId = feed.getId();
             String title = feed.getTitle();
             String author = feed.getAuthor().getNickName();
-            String authorProfileImage = feed.getAuthor().getProfileImage();
+            String profileImageNullable = feed.getAuthor().getProfileImage();
+            String authorProfileImage = (profileImageNullable == null) ? "" : profileImageNullable;
             if (feed.getFeedImages().size() == 0) {
                 return new UserFeedResponse(feedId, title, null, author, authorProfileImage);
             }

--- a/src/main/java/com/shy_polarbear/server/domain/user/dto/user/response/UserFeedsResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/user/dto/user/response/UserFeedsResponse.java
@@ -26,7 +26,7 @@ public class UserFeedsResponse {
 
         private static UserFeedResponse from(Feed feed) {
             if (feed.getFeedImages().size() == 0) {
-                return new UserFeedResponse(feed.getId(), feed.getTitle(), null);
+                return new UserFeedResponse(feed.getId(), feed.getTitle(), "");
             }
             return new UserFeedResponse(feed.getId(), feed.getTitle(), feed.getFeedImages().get(0).getUrl());
         }

--- a/src/main/java/com/shy_polarbear/server/domain/user/dto/user/response/UserInfoResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/user/dto/user/response/UserInfoResponse.java
@@ -14,7 +14,7 @@ public class UserInfoResponse {
     @Builder
     private UserInfoResponse(String nickName, String profileImage, String email, String phoneNumber) {
         this.nickName = nickName;
-        this.profileImage = profileImage;
+        this.profileImage = profileImage == null ? "" : profileImage;
         this.email = email;
         this.phoneNumber = phoneNumber;
     }


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 내 정보 수정, 회원 가입 시 프로필 이미지 필수 아니게 변경
- 유저 프로필 이미지 링크를 내려줄 시, null이 아닌 빈값으로 응답
- 피드에 이미지가 없을 시, null이 아닌 빈값으로 응답
