### PR TITLE
퀴즈 리팩토링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,10 @@ out/
 ### VS Code ###
 .vscode/
 
-*.yml
+application.yml
+application-local.yml
+application-dev.yml
+application-prod.yml
 application.properties
 
 ### just memo

--- a/src/main/java/com/shy_polarbear/server/domain/point/service/PointService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/point/service/PointService.java
@@ -18,14 +18,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class PointService {
     private final PointRepository pointRepository;
 
-    // 환경 문제 맞춘 경우
+    // 환경 문제 포인트 계산
     @Transactional(propagation = Propagation.MANDATORY)  // TODO: 트랜잭션 전파 고민. 포폴 먹거리
     public int calculateQuizSubmissionPoint(boolean isCorrect, User user) {
-        if (!isCorrect) {// 정답 여부에 따라 다르게 계산
-            return PointType.NOT_SOLVE_QUIZ.getValue();
-        } else {
+        if (isCorrect) {// 정답 여부에 따라 다르게 계산
             pointRepository.save(Point.createPoint(user, PointType.SOLVE_QUIZ));
             return PointType.SOLVE_QUIZ.getValue();
+        } else {
+            return PointType.NOT_SOLVE_QUIZ.getValue();
         }
     }
 }

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/controller/QuizController.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/controller/QuizController.java
@@ -1,6 +1,11 @@
 package com.shy_polarbear.server.domain.quiz.controller;
 
-import com.shy_polarbear.server.domain.quiz.dto.*;
+import com.shy_polarbear.server.domain.quiz.dto.request.MultipleChoiceQuizScoreRequest;
+import com.shy_polarbear.server.domain.quiz.dto.request.OXQuizScoreRequest;
+import com.shy_polarbear.server.domain.quiz.dto.response.MultipleChoiceQuizScoreResponse;
+import com.shy_polarbear.server.domain.quiz.dto.response.OXQuizScoreResponse;
+import com.shy_polarbear.server.domain.quiz.dto.response.QuizCardResponse;
+import com.shy_polarbear.server.domain.quiz.dto.response.WhetherDailyQuizSolvedResponse;
 import com.shy_polarbear.server.domain.quiz.service.QuizService;
 import com.shy_polarbear.server.global.auth.security.PrincipalDetails;
 import com.shy_polarbear.server.global.common.constants.BusinessLogicConstants;

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/dto/request/MultipleChoiceQuizScoreRequest.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/dto/request/MultipleChoiceQuizScoreRequest.java
@@ -1,4 +1,4 @@
-package com.shy_polarbear.server.domain.quiz.dto;
+package com.shy_polarbear.server.domain.quiz.dto.request;
 
 import javax.validation.constraints.NotNull;
 

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/dto/request/OXQuizScoreRequest.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/dto/request/OXQuizScoreRequest.java
@@ -1,4 +1,4 @@
-package com.shy_polarbear.server.domain.quiz.dto;
+package com.shy_polarbear.server.domain.quiz.dto.request;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/dto/response/MultipleChoiceQuizScoreResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/dto/response/MultipleChoiceQuizScoreResponse.java
@@ -1,4 +1,4 @@
-package com.shy_polarbear.server.domain.quiz.dto;
+package com.shy_polarbear.server.domain.quiz.dto.response;
 
 import com.shy_polarbear.server.domain.quiz.model.MultipleChoice;
 import com.shy_polarbear.server.domain.quiz.model.MultipleChoiceQuiz;

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/dto/response/MultipleChoiceResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/dto/response/MultipleChoiceResponse.java
@@ -1,4 +1,4 @@
-package com.shy_polarbear.server.domain.quiz.dto;
+package com.shy_polarbear.server.domain.quiz.dto.response;
 
 import com.shy_polarbear.server.domain.quiz.model.MultipleChoice;
 import lombok.Builder;

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/dto/response/OXQuizScoreResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/dto/response/OXQuizScoreResponse.java
@@ -1,4 +1,4 @@
-package com.shy_polarbear.server.domain.quiz.dto;
+package com.shy_polarbear.server.domain.quiz.dto.response;
 
 import com.shy_polarbear.server.domain.quiz.model.OXQuiz;
 import lombok.Builder;

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/dto/response/QuizCardResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/dto/response/QuizCardResponse.java
@@ -1,8 +1,8 @@
-package com.shy_polarbear.server.domain.quiz.dto;
+package com.shy_polarbear.server.domain.quiz.dto.response;
 
+import com.shy_polarbear.server.domain.quiz.dto.QuizType;
 import com.shy_polarbear.server.domain.quiz.model.MultipleChoiceQuiz;
 import com.shy_polarbear.server.domain.quiz.model.OXQuiz;
-import com.shy_polarbear.server.domain.quiz.model.Quiz;
 import com.shy_polarbear.server.global.common.constants.BusinessLogicConstants;
 import lombok.Builder;
 

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/dto/response/WhetherDailyQuizSolvedResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/dto/response/WhetherDailyQuizSolvedResponse.java
@@ -1,4 +1,4 @@
-package com.shy_polarbear.server.domain.quiz.dto;
+package com.shy_polarbear.server.domain.quiz.dto.response;
 
 import lombok.Builder;
 

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/model/MultipleChoice.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/model/MultipleChoice.java
@@ -1,6 +1,8 @@
 package com.shy_polarbear.server.domain.quiz.model;
 
+import com.shy_polarbear.server.domain.quiz.exception.QuizException;
 import com.shy_polarbear.server.global.common.model.BaseEntity;
+import com.shy_polarbear.server.global.exception.ExceptionStatus;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,7 +33,15 @@ public class MultipleChoice extends BaseEntity {
     public MultipleChoice(String content, boolean isAnswer, MultipleChoiceQuiz multipleChoiceQuiz) {
         this.content = content;
         this.isAnswer = isAnswer;
-        this.multipleChoiceQuiz = multipleChoiceQuiz;
+        setInitialMultipleChoiceQuiz(multipleChoiceQuiz);
     }
 
+    private void setInitialMultipleChoiceQuiz(MultipleChoiceQuiz multipleChoiceQuiz) {
+        if (this.multipleChoiceQuiz != null) {  // 선택지는 부모(퀴즈)가 변경될 일 없음
+            throw new QuizException(ExceptionStatus.SERVER_ERROR);
+        }
+
+        this.multipleChoiceQuiz = multipleChoiceQuiz;
+        multipleChoiceQuiz.getMultipleChoiceList().add(this);
+    }
 }

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/model/MultipleChoiceQuiz.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/model/MultipleChoiceQuiz.java
@@ -18,8 +18,7 @@ public class MultipleChoiceQuiz extends Quiz {
     private List<MultipleChoice> multipleChoiceList = new ArrayList<>();
 
     @Builder
-    public MultipleChoiceQuiz(String question, String explanation, List<MultipleChoice> multipleChoiceList) {
+    public MultipleChoiceQuiz(String question, String explanation) {
         super(question, explanation);
-        this.multipleChoiceList = multipleChoiceList;
     }
 }

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/model/UserQuiz.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/model/UserQuiz.java
@@ -67,10 +67,4 @@ public class UserQuiz extends BaseEntity {
         user.addUserQuiz(userQuiz);
         return userQuiz;
     }
-
-    //연관관계 편의 메서드
-    public void assignUser(User user) {
-        this.user = user;
-        user.addUserQuiz(this);
-    }
 }

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/model/UserQuiz.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/model/UserQuiz.java
@@ -44,6 +44,30 @@ public class UserQuiz extends BaseEntity {
         this.submittedMultipleChoiceAnswer = submittedMultipleChoiceAnswer;
     }
 
+    public static UserQuiz createUserOXQuiz(User user, Quiz quiz, boolean correct, OXChoice submittedOXAnswer) {
+        UserQuiz userQuiz = UserQuiz.builder()
+                .user(user)
+                .quiz(quiz)
+                .correct(correct)
+                .submittedOXAnswer(submittedOXAnswer)
+                .build();
+
+        user.addUserQuiz(userQuiz);
+        return userQuiz;
+    }
+
+    public static UserQuiz createUserMultipleChoiceQuiz(User user, Quiz quiz, boolean correct, MultipleChoice submittedMultipleChoiceAnswer) {
+        UserQuiz userQuiz = UserQuiz.builder()
+                .user(user)
+                .quiz(quiz)
+                .correct(correct)
+                .submittedMultipleChoiceAnswer(submittedMultipleChoiceAnswer)
+                .build();
+
+        user.addUserQuiz(userQuiz);
+        return userQuiz;
+    }
+
     //연관관계 편의 메서드
     public void assignUser(User user) {
         this.user = user;

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/repository/UserQuizRepository.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/repository/UserQuizRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserQuizRepository extends JpaRepository<UserQuiz, Long> {
-    // TODO: 불필요하게 발생하는 LEFT OUTER JOIN 제거
+public interface UserQuizRepository extends JpaRepository<UserQuiz, Long>, UserQuizRepositoryCustom {
+    // deprecated
     Optional<UserQuiz> findFirstByCreatedDateStartingWithAndUserIdOrderByCreatedDateDesc(String localDateTime, Long userId);
 }

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/repository/UserQuizRepositoryCustom.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/repository/UserQuizRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.shy_polarbear.server.domain.quiz.repository;
+
+import com.shy_polarbear.server.domain.quiz.model.UserQuiz;
+
+import java.util.Optional;
+
+public interface UserQuizRepositoryCustom {
+    Optional<UserQuiz> findFirstSubmittedDailyQuizByUser(String localDateTime, Long userId);
+
+}

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/repository/UserQuizRepositoryImpl.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/repository/UserQuizRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.shy_polarbear.server.domain.quiz.repository;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.shy_polarbear.server.domain.quiz.model.QUserQuiz;
+import com.shy_polarbear.server.domain.quiz.model.UserQuiz;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+import static com.shy_polarbear.server.domain.quiz.model.QUserQuiz.userQuiz;
+
+@RequiredArgsConstructor
+public class UserQuizRepositoryImpl implements UserQuizRepositoryCustom{
+    private final JPAQueryFactory queryFactory;
+    @Override
+    public Optional<UserQuiz> findFirstSubmittedDailyQuizByUser(String localDateTime, Long userId) {
+        JPAQuery<UserQuiz> query = queryFactory.selectFrom(userQuiz)
+                .where(userQuiz.createdDate.startsWith(localDateTime).and(userQuiz.user.id.eq(userId)))
+                .orderBy(userQuiz.createdDate.desc());
+
+        return Optional.ofNullable(query.fetchFirst());
+    }
+}

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/service/QuizService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/service/QuizService.java
@@ -55,7 +55,7 @@ public class QuizService {
     // 데일리 퀴즈 풀이 여부 조회 : 오늘 0시 0분 0초를 기준으로 해당 유저가 제출한 문제를 조회
     public WhetherDailyQuizSolvedResponse getWhetherDailyQuizSolved(Long currentUserId) {
         LocalDate today = LocalDate.now();
-        Optional<UserQuiz> optionalUserQuiz = userQuizRepository.findFirstByCreatedDateStartingWithAndUserIdOrderByCreatedDateDesc(today.toString(), currentUserId);
+        Optional<UserQuiz> optionalUserQuiz = userQuizRepository.findFirstSubmittedDailyQuizByUser(today.toString(), currentUserId);
 
         boolean isSubmitted = optionalUserQuiz.isPresent();    // 레코드 존재 여부
         Long quizId = isSubmitted ? optionalUserQuiz.get().getQuiz().getId() : null; // 존재 여부에 따라 id값 할당

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/service/QuizService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/service/QuizService.java
@@ -1,7 +1,12 @@
 package com.shy_polarbear.server.domain.quiz.service;
 
 import com.shy_polarbear.server.domain.point.service.PointService;
-import com.shy_polarbear.server.domain.quiz.dto.*;
+import com.shy_polarbear.server.domain.quiz.dto.request.MultipleChoiceQuizScoreRequest;
+import com.shy_polarbear.server.domain.quiz.dto.request.OXQuizScoreRequest;
+import com.shy_polarbear.server.domain.quiz.dto.response.MultipleChoiceQuizScoreResponse;
+import com.shy_polarbear.server.domain.quiz.dto.response.OXQuizScoreResponse;
+import com.shy_polarbear.server.domain.quiz.dto.response.QuizCardResponse;
+import com.shy_polarbear.server.domain.quiz.dto.response.WhetherDailyQuizSolvedResponse;
 import com.shy_polarbear.server.domain.quiz.exception.QuizException;
 import com.shy_polarbear.server.domain.quiz.model.*;
 import com.shy_polarbear.server.domain.quiz.repository.*;

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/service/QuizService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/service/QuizService.java
@@ -78,14 +78,9 @@ public class QuizService {
 
         OXChoice submittedChoice = OXChoice.toEnum(request.answer());
         boolean isCorrect = submittedChoice.equals(oxQuiz.getAnswer()); // 제출된 답안과 실제 답 비교
-        int pointValue = pointService.calculateQuizSubmissionPoint(isCorrect, user);    // 포인트 처리
+        userQuizRepository.save(UserQuiz.createUserOXQuiz(user, oxQuiz, isCorrect, submittedChoice));
 
-        userQuizRepository.save(UserQuiz.builder() // UserQuiz 레코드 저장
-                .user(user)
-                .quiz(oxQuiz)
-                .submittedOXAnswer(submittedChoice)
-                .correct(isCorrect)
-                .build());
+        int pointValue = pointService.calculateQuizSubmissionPoint(isCorrect, user);    // 포인트 처리
 
         return OXQuizScoreResponse.of(oxQuiz, isCorrect, pointValue);
     }
@@ -98,22 +93,16 @@ public class QuizService {
                 .orElseThrow(() -> new QuizException(ExceptionStatus.NOT_FOUND_QUIZ));
         List<MultipleChoice> multipleChoiceList = multipleChoiceRepository.findAllByMultipleChoiceQuizId(quizId);
 
-        Long submittedChoiceId = request.answerId();
-        MultipleChoice submittedChoice = multipleChoiceList.stream().filter(it -> it.getId().equals(submittedChoiceId)).findFirst()
+        MultipleChoice submittedChoice = multipleChoiceList.stream().filter(it -> it.getId().equals(request.answerId())).findFirst()
                 .orElseThrow(() -> new QuizException(ExceptionStatus.NOT_FOUND_CHOICE));
         MultipleChoice answer = multipleChoiceList.stream().filter(MultipleChoice::isAnswer).findFirst()
                 .orElseThrow(() -> new QuizException(ExceptionStatus.SERVER_ERROR));    // 답이 없는 퀴즈는 서버쪽 오류
 
         boolean isCorrect = submittedChoice.equals(answer); // 제출된 답안과 실제 답 비교
+        userQuizRepository.save(UserQuiz.createUserMultipleChoiceQuiz(user, multipleChoiceQuiz, isCorrect, submittedChoice));
+
         int pointValue = pointService.calculateQuizSubmissionPoint(isCorrect, user);    // 포인트 처리
         int sequence = multipleChoiceList.indexOf(answer) + 1;// 정답 선택지의 순서
-
-        userQuizRepository.save(UserQuiz.builder() // UserQuiz 레코드 저장
-                .user(user)
-                .quiz(multipleChoiceQuiz)
-                .submittedMultipleChoiceAnswer(submittedChoice)
-                .correct(isCorrect)
-                .build());
 
         return MultipleChoiceQuizScoreResponse.of(multipleChoiceQuiz, sequence, answer, isCorrect, pointValue);
     }

--- a/src/main/java/com/shy_polarbear/server/global/common/dummy/QuizInitializer.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/dummy/QuizInitializer.java
@@ -51,23 +51,26 @@ public class QuizInitializer {  // TODO: 지금 로직은 지속가능하지 않
     }
 
     private void createDummyMultipleChoiceQuiz() {
-        MultipleChoiceQuiz quiz1 = quizRepository.save(MultipleChoiceQuiz.builder().question("다음 중 일반 쓰레기가 아닌 것은?").explanation("정답은 바나나 껍질!!\n이 밖에도 파인애플 껍질은 일반쓰레기, 바나나 겁질은 음식물쓰레기, 족발 뼈나 갈비뼈 등은 일반쓰레기라는 점 기억해주세요!").build());
-        multipleChoiceRepository.save(MultipleChoice.builder().multipleChoiceQuiz(quiz1).isAnswer(false).content("견과류 껍데기").build());
-        multipleChoiceRepository.save(MultipleChoice.builder().multipleChoiceQuiz(quiz1).isAnswer(false).content("일회용 티백").build());
-        multipleChoiceRepository.save(MultipleChoice.builder().multipleChoiceQuiz(quiz1).isAnswer(true).content("바나나 껍질").build());
-        multipleChoiceRepository.save(MultipleChoice.builder().multipleChoiceQuiz(quiz1).isAnswer(false).content("계란 껍데기").build());
+        MultipleChoiceQuiz quiz1 = MultipleChoiceQuiz.builder().question("다음 중 일반 쓰레기가 아닌 것은?").explanation("정답은 바나나 껍질!!\n이 밖에도 파인애플 껍질은 일반쓰레기, 바나나 겁질은 음식물쓰레기, 족발 뼈나 갈비뼈 등은 일반쓰레기라는 점 기억해주세요!").build();
+        MultipleChoice.builder().multipleChoiceQuiz(quiz1).isAnswer(false).content("견과류 껍데기").build();
+        MultipleChoice.builder().multipleChoiceQuiz(quiz1).isAnswer(false).content("일회용 티백").build();
+        MultipleChoice.builder().multipleChoiceQuiz(quiz1).isAnswer(true).content("바나나 껍질").build();
+        MultipleChoice.builder().multipleChoiceQuiz(quiz1).isAnswer(false).content("계란 껍데기").build();
+        quizRepository.save(quiz1);
 
-        MultipleChoiceQuiz quiz2 = quizRepository.save(MultipleChoiceQuiz.builder().question("에너지를 절약할 수 있는 겨울철 적정 실내온도는?").explanation("보건복지부와 질병관리본부에서 정한 18~20도는 난방에너지 절약이 가능하며, 이보다 높은 실내온도를 유지할 경우 추운 날씨에 대한 인체 적응력 및 면역력이 떨어진다고 합니다.").build());
-        multipleChoiceRepository.save(MultipleChoice.builder().multipleChoiceQuiz(quiz2).isAnswer(false).content("13-16도").build());
-        multipleChoiceRepository.save(MultipleChoice.builder().multipleChoiceQuiz(quiz2).isAnswer(false).content("16-18도").build());
-        multipleChoiceRepository.save(MultipleChoice.builder().multipleChoiceQuiz(quiz2).isAnswer(true).content("18-20도").build());
-        multipleChoiceRepository.save(MultipleChoice.builder().multipleChoiceQuiz(quiz2).isAnswer(false).content("26-28도").build());
+        MultipleChoiceQuiz quiz2 = MultipleChoiceQuiz.builder().question("에너지를 절약할 수 있는 겨울철 적정 실내온도는?").explanation("보건복지부와 질병관리본부에서 정한 18~20도는 난방에너지 절약이 가능하며, 이보다 높은 실내온도를 유지할 경우 추운 날씨에 대한 인체 적응력 및 면역력이 떨어진다고 합니다.").build();
+        MultipleChoice.builder().multipleChoiceQuiz(quiz2).isAnswer(false).content("13-16도").build();
+        MultipleChoice.builder().multipleChoiceQuiz(quiz2).isAnswer(false).content("16-18도").build();
+        MultipleChoice.builder().multipleChoiceQuiz(quiz2).isAnswer(true).content("18-20도").build();
+        MultipleChoice.builder().multipleChoiceQuiz(quiz2).isAnswer(false).content("26-28도").build();
+        quizRepository.save(quiz2);
 
-        MultipleChoiceQuiz quiz3 = quizRepository.save(MultipleChoiceQuiz.builder().question("세계 환경의 날은 언제일까?").explanation("유연환경계획(UNEP)은 1987년부터 매년 세계 환경의 날을 맞아 그해의 주제를 선정 및 발표하며, 대륙별로 돌아가며 한 나라를 정해 행사를 개최하고 있는데요. 한국에서도 1997년에 세계 환경의 날 행사를 개최했습니다 :)").build());
-        multipleChoiceRepository.save(MultipleChoice.builder().multipleChoiceQuiz(quiz3).isAnswer(false).content("3월 22일").build());
-        multipleChoiceRepository.save(MultipleChoice.builder().multipleChoiceQuiz(quiz3).isAnswer(false).content("4월 22일").build());
-        multipleChoiceRepository.save(MultipleChoice.builder().multipleChoiceQuiz(quiz3).isAnswer(true).content("5월 31일").build());
-        multipleChoiceRepository.save(MultipleChoice.builder().multipleChoiceQuiz(quiz3).isAnswer(false).content("6월 5일").build());
+        MultipleChoiceQuiz quiz3 = MultipleChoiceQuiz.builder().question("세계 환경의 날은 언제일까?").explanation("유연환경계획(UNEP)은 1987년부터 매년 세계 환경의 날을 맞아 그해의 주제를 선정 및 발표하며, 대륙별로 돌아가며 한 나라를 정해 행사를 개최하고 있는데요. 한국에서도 1997년에 세계 환경의 날 행사를 개최했습니다 :)").build();
+        MultipleChoice.builder().multipleChoiceQuiz(quiz3).isAnswer(false).content("3월 22일").build();
+        MultipleChoice.builder().multipleChoiceQuiz(quiz3).isAnswer(false).content("4월 22일").build();
+        MultipleChoice.builder().multipleChoiceQuiz(quiz3).isAnswer(true).content("5월 31일").build();
+        MultipleChoice.builder().multipleChoiceQuiz(quiz3).isAnswer(false).content("6월 5일").build();
+        quizRepository.save(quiz3);
     }
 
 }

--- a/src/main/java/com/shy_polarbear/server/global/common/dummy/QuizInitializer.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/dummy/QuizInitializer.java
@@ -1,14 +1,10 @@
 package com.shy_polarbear.server.global.common.dummy;
 
-import com.shy_polarbear.server.domain.quiz.model.*;
-import com.shy_polarbear.server.domain.quiz.repository.MultipleChoiceRepository;
-import com.shy_polarbear.server.domain.quiz.repository.OXQuizRepository;
+import com.shy_polarbear.server.domain.quiz.model.MultipleChoice;
+import com.shy_polarbear.server.domain.quiz.model.MultipleChoiceQuiz;
+import com.shy_polarbear.server.domain.quiz.model.OXChoice;
+import com.shy_polarbear.server.domain.quiz.model.OXQuiz;
 import com.shy_polarbear.server.domain.quiz.repository.QuizRepository;
-import com.shy_polarbear.server.domain.quiz.repository.UserQuizRepository;
-import com.shy_polarbear.server.domain.user.exception.UserException;
-import com.shy_polarbear.server.domain.user.model.User;
-import com.shy_polarbear.server.domain.user.repository.UserRepository;
-import com.shy_polarbear.server.global.exception.ExceptionStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.DependsOn;
@@ -24,10 +20,6 @@ import javax.transaction.Transactional;
 @Transactional
 public class QuizInitializer {  // TODO: 지금 로직은 지속가능하지 않음. 퀴즈 업데이트를 한다면..?
     private final QuizRepository quizRepository;
-    private final OXQuizRepository oxQuizRepository;
-    private final MultipleChoiceRepository multipleChoiceRepository;
-    private final UserRepository userRepository;
-    private final UserQuizRepository userQuizRepository;
 
     @PostConstruct
     public void init() {


### PR DESCRIPTION
🌱 작업한 내용
- Must 파트만 리팩토링. API 명세상의 변경이나 서비스 로직상의 변경은 없습니다

🌱 PR 포인트 (커밋 이력과 동일)
- 객관식 퀴즈 연관관계 메서드 : 영속성 컨텍스트 시점에 조회되지 않는 오류 해결
- `QuizRepositoryImpl` 리팩토링 실패. 단일 테이블 전략의 FETCH JOIN은 QueryDSL에서 지원하지 않는듯 합니다.. 
- UserQuiz 조회 쿼리문 최적화 : Spring Data JPA -> QueryDSL로 변경하여 기존의 불필요한 LEFT JOIN 발생하는 문제 해결
- DTO 파일 구조 변경 : request, response 패키지로 분리
- yml 프로필별로 관리 -> gitignore에 추가

:bulb: 공유하고 싶은 내용

인텔리제이에서 프로필 설정을 해주고 yml에도 동일하게 설정해주면 상황별로 다르게 서버를 작동시킬 수 있습니다!
전 개발할 때 주로 로컬 DB를 사용 + JWT 만료기간 10일로 설정하는 등 설정이 조금씩 달라서 이런 부분에서 편해요
그리고 실수로 RDS DB에다 create-drop 할 일도 없어져서 좋은거같아요

![image](https://github.com/ShyPolarBear/Server/assets/72124326/403e012b-ca80-4f3a-a9d4-92dec9dd4439)
![image](https://github.com/ShyPolarBear/Server/assets/72124326/22f21276-1c17-437e-9135-debe6635cac4)

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|

## 📮 관련 이슈
- Resolved: #52 
