### PR TITLE
fix: 퀴즈 Request DTO Json parse error

### DIFF
--- a/src/main/java/com/shy_polarbear/server/domain/quiz/dto/request/MultipleChoiceQuizScoreRequest.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/dto/request/MultipleChoiceQuizScoreRequest.java
@@ -1,9 +1,14 @@
 package com.shy_polarbear.server.domain.quiz.dto.request;
 
+import lombok.Builder;
+
 import javax.validation.constraints.NotNull;
 
 public record MultipleChoiceQuizScoreRequest(
         @NotNull
         Long answerId
 ) {
+        @Builder
+        public MultipleChoiceQuizScoreRequest {
+        }
 }

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/dto/request/OXQuizScoreRequest.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/dto/request/OXQuizScoreRequest.java
@@ -1,5 +1,7 @@
 package com.shy_polarbear.server.domain.quiz.dto.request;
 
+import lombok.Builder;
+
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
@@ -7,4 +9,7 @@ public record OXQuizScoreRequest(
         @NotBlank @Size(max = 1)
         String answer
 ) {
+        @Builder
+        public OXQuizScoreRequest {
+        }
 }


### PR DESCRIPTION
## 📌 PR 요약

- DTO에 생성자 추가

🌱 작업한 내용
- OX퀴즈 DTO 수정
- 객관식 퀴즈 DTO 수정

🌱 PR 포인트
- 문제 원인 : DTO 생성자 누락으로 인한 Json 파싱 에러

```
JSON parse error: Cannot construct instance of `com.shy_polarbear.server.domain.quiz.dto.MultipleChoiceQuizScoreRequest` (although at least one Creator exists): no int/Int-argument constructor/factory method to deserialize from Number value (12)
```

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|

## 📮 관련 이슈
- Resolved: #이슈번호
