### PR TITLE
Feature/전체 피드 조회

### DIFF
--- a/src/main/java/com/shy_polarbear/server/domain/comment/model/Comment.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/model/Comment.java
@@ -77,4 +77,8 @@ public class Comment extends BaseEntity {
         this.parent = comment;
     }
 
+    public boolean isAuthor(User user) {
+        return this.author.getId().equals(user.getId());
+    }
+    
 }

--- a/src/main/java/com/shy_polarbear/server/domain/comment/model/Comment.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/model/Comment.java
@@ -80,5 +80,9 @@ public class Comment extends BaseEntity {
     public boolean isAuthor(User user) {
         return this.author.getId().equals(user.getId());
     }
-    
+
+    public boolean isLike(User user) {
+        return commentLikes.stream()
+                .anyMatch(commentLike -> commentLike.isAuthor(user));
+    }
 }

--- a/src/main/java/com/shy_polarbear/server/domain/comment/model/CommentLike.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/model/CommentLike.java
@@ -41,4 +41,8 @@ public class CommentLike extends BaseEntity {
         return commentLike;
     }
 
+    public boolean isAuthor(User user) {
+        return this.user.getId().equals(user.getId());
+
+    }
 }

--- a/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,9 @@
+package com.shy_polarbear.server.domain.comment.repository;
+
+import com.shy_polarbear.server.domain.comment.model.Comment;
+import com.shy_polarbear.server.domain.user.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    boolean existsByUserAndComment(User user, Comment comment);
+}

--- a/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepository.java
@@ -1,9 +1,7 @@
 package com.shy_polarbear.server.domain.comment.repository;
 
 import com.shy_polarbear.server.domain.comment.model.Comment;
-import com.shy_polarbear.server.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
-    boolean existsByUserAndComment(User user, Comment comment);
 }

--- a/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepository.java
@@ -4,6 +4,6 @@ import com.shy_polarbear.server.domain.comment.model.Comment;
 import com.shy_polarbear.server.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
     boolean existsByUserAndComment(User user, Comment comment);
 }

--- a/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryCustom.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryCustom.java
@@ -3,7 +3,9 @@ package com.shy_polarbear.server.domain.comment.repository;
 import com.shy_polarbear.server.domain.comment.model.Comment;
 import com.shy_polarbear.server.domain.feed.model.Feed;
 
+import java.util.Optional;
+
 public interface CommentRepositoryCustom {
 
-    Comment findBestComment(Feed feed);
+    Optional<Comment> findBestComment(Feed feed);
 }

--- a/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryCustom.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.shy_polarbear.server.domain.comment.repository;
+
+import com.shy_polarbear.server.domain.comment.model.Comment;
+import com.shy_polarbear.server.domain.feed.model.Feed;
+
+public interface CommentRepositoryCustom {
+
+    Comment findBestComment(Feed feed);
+}

--- a/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.shy_polarbear.server.domain.comment.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.shy_polarbear.server.domain.comment.model.Comment;
+import com.shy_polarbear.server.domain.comment.model.QComment;
+import com.shy_polarbear.server.domain.feed.model.Feed;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import static com.shy_polarbear.server.domain.comment.model.QComment.*;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentRepositoryImpl implements CommentRepositoryCustom{
+    private final JPAQueryFactory queryFactory;
+    @Override
+    public Comment findBestComment(Feed feed) {
+        JPAQuery<Comment> query = queryFactory
+                .selectFrom(comment)
+                .where(checkFeed(feed))
+                .orderBy(
+                        comment.commentLikes.size().desc(),
+                        comment.createdDate.desc()
+                )
+                .limit(1);
+        return query.fetchOne();
+    }
+
+    private static BooleanExpression checkFeed(Feed feed) {
+        return comment.feed.id.eq(feed.getId());
+    }
+}

--- a/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryImpl.java
@@ -24,9 +24,8 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom{
                 .orderBy(
                         comment.commentLikes.size().desc(),
                         comment.createdDate.desc()
-                )
-                .limit(1);
-        return Optional.ofNullable(query.fetchOne());
+                );
+        return Optional.ofNullable(query.fetchFirst());
     }
 
     private static BooleanExpression checkFeed(Feed feed) {

--- a/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryImpl.java
@@ -4,10 +4,11 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.shy_polarbear.server.domain.comment.model.Comment;
-import com.shy_polarbear.server.domain.comment.model.QComment;
 import com.shy_polarbear.server.domain.feed.model.Feed;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 import static com.shy_polarbear.server.domain.comment.model.QComment.*;
 
@@ -16,7 +17,7 @@ import static com.shy_polarbear.server.domain.comment.model.QComment.*;
 public class CommentRepositoryImpl implements CommentRepositoryCustom{
     private final JPAQueryFactory queryFactory;
     @Override
-    public Comment findBestComment(Feed feed) {
+    public Optional<Comment> findBestComment(Feed feed) {
         JPAQuery<Comment> query = queryFactory
                 .selectFrom(comment)
                 .where(checkFeed(feed))
@@ -25,7 +26,7 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom{
                         comment.createdDate.desc()
                 )
                 .limit(1);
-        return query.fetchOne();
+        return Optional.ofNullable(query.fetchOne());
     }
 
     private static BooleanExpression checkFeed(Feed feed) {

--- a/src/main/java/com/shy_polarbear/server/domain/comment/service/CommentService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/service/CommentService.java
@@ -1,0 +1,4 @@
+package com.shy_polarbear.server.domain.comment.service;
+
+public class CommentService {
+}

--- a/src/main/java/com/shy_polarbear/server/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/controller/FeedController.java
@@ -28,7 +28,7 @@ public class FeedController {
     }
 
     @GetMapping
-    public ApiResponse<?> findAllFeeds(@RequestParam String sort,
+    public ApiResponse<PageResponse<FeedCardResponse>> findAllFeeds(@RequestParam String sort,
                                       @RequestParam(required = false) Long lastFeedId,
                                       @RequestParam(required = false, defaultValue = BusinessLogicConstants.FEED_LIMIT_PARAM_DEFAULT_VALUE) int limit,
                                        @AuthenticationPrincipal PrincipalDetails principalDetails) {

--- a/src/main/java/com/shy_polarbear/server/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/controller/FeedController.java
@@ -30,8 +30,9 @@ public class FeedController {
     @GetMapping
     public ApiResponse<?> findAllFeeds(@RequestParam String sort,
                                       @RequestParam(required = false) Long lastFeedId,
-                                      @RequestParam(required = false, defaultValue = BusinessLogicConstants.FEED_LIMIT_PARAM_DEFAULT_VALUE) int limit) {
-        return ApiResponse.success(feedService.findAllFeeds(sort, lastFeedId, limit));
+                                      @RequestParam(required = false, defaultValue = BusinessLogicConstants.FEED_LIMIT_PARAM_DEFAULT_VALUE) int limit,
+                                       @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        return ApiResponse.success(feedService.findAllFeeds(sort, lastFeedId, limit, principalDetails.getUser()));
     }
 
     @GetMapping("/{feedId}")

--- a/src/main/java/com/shy_polarbear/server/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/controller/FeedController.java
@@ -5,7 +5,9 @@ import com.shy_polarbear.server.domain.feed.dto.request.UpdateFeedRequest;
 import com.shy_polarbear.server.domain.feed.dto.response.*;
 import com.shy_polarbear.server.domain.feed.service.FeedService;
 import com.shy_polarbear.server.global.auth.security.PrincipalDetails;
+import com.shy_polarbear.server.global.common.constants.BusinessLogicConstants;
 import com.shy_polarbear.server.global.common.dto.ApiResponse;
+import com.shy_polarbear.server.global.common.dto.PageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -28,8 +30,8 @@ public class FeedController {
     @GetMapping
     public ApiResponse<?> findAllFeeds(@RequestParam String sort,
                                       @RequestParam(required = false) Long lastFeedId,
-                                      @RequestParam(required = false) String limit) {
-        return null;
+                                      @RequestParam(required = false, defaultValue = BusinessLogicConstants.FEED_LIMIT_PARAM_DEFAULT_VALUE) int limit) {
+        return ApiResponse.success(feedService.findAllFeeds(sort, lastFeedId, limit));
     }
 
     @GetMapping("/{feedId}")

--- a/src/main/java/com/shy_polarbear/server/domain/feed/dto/response/FeedCardResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/dto/response/FeedCardResponse.java
@@ -43,8 +43,7 @@ public class FeedCardResponse {
         private String createdDate;
     }
 
-    public static FeedCardResponse of(Feed feed, Boolean isFeedAuthor, Boolean isFeedLike,
-                                      int commentCount, Comment comment, Boolean isCommentAuthor, Boolean isCommentLike) {
+    public static FeedCardResponse of(Feed feed, Comment comment, User user) {
         User commentAuthor = comment.getAuthor();
         FeedCommentResponse feedCommentResponse = FeedCommentResponse.builder()
                 .commentId(comment.getId())
@@ -52,8 +51,8 @@ public class FeedCardResponse {
                 .authorProfileImage((commentAuthor.getProfileImage() == null) ? "" : commentAuthor.getProfileImage())
                 .content(comment.getContent())
                 .likeCount(comment.getCommentLikes().size())
-                .isAuthor(isCommentAuthor)
-                .isLike(isCommentLike)
+                .isAuthor(comment.isAuthor(user))
+                .isLike(comment.isLike(user))
                 .createdDate(comment.getCreatedDate())
                 .build();
 
@@ -67,9 +66,9 @@ public class FeedCardResponse {
                 .author(feedAuthor.getNickName())
                 .authorProfileImage((feedAuthor.getProfileImage() == null) ? "" : feedAuthor.getProfileImage())
                 .createdDate(feed.getCreatedDate())
-                .isLike(isFeedLike)
-                .isAuthor(isFeedAuthor)
-                .commentCount(commentCount)
+                .isLike(feed.isLike(user))
+                .isAuthor(feed.isAuthor(user))
+                .commentCount(feed.getComments().size())
                 .comment(feedCommentResponse)
                 .build();
         return feedCardResponse;

--- a/src/main/java/com/shy_polarbear/server/domain/feed/dto/response/FeedCardResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/dto/response/FeedCardResponse.java
@@ -1,0 +1,77 @@
+package com.shy_polarbear.server.domain.feed.dto.response;
+
+import com.shy_polarbear.server.domain.comment.model.Comment;
+import com.shy_polarbear.server.domain.feed.model.Feed;
+import com.shy_polarbear.server.domain.user.model.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class FeedCardResponse {
+    private Long feedId;
+    private String title;
+    private String content;
+    private Integer likeCount;
+    private List<String> feedImages;
+    private String author;
+    private String authorProfileImage;
+    private String createdDate;
+    private Boolean isLike;
+    private Boolean isAuthor;
+    private Integer commentCount;
+    private FeedCommentResponse comment;
+
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    public static class FeedCommentResponse {
+        private Long commentId;
+        private String author;
+        private String authorProfileImage;
+        private String content;
+        private Integer likeCount;
+        private Boolean isAuthor;
+        private Boolean isLike;
+        private String createdDate;
+    }
+
+    public static FeedCardResponse of(Feed feed, Boolean isFeedAuthor, Boolean isFeedLike,
+                                      int commentCount, Comment comment, Boolean isCommentAuthor, Boolean isCommentLike) {
+        User commentAuthor = comment.getAuthor();
+        FeedCommentResponse feedCommentResponse = FeedCommentResponse.builder()
+                .commentId(comment.getId())
+                .author(commentAuthor.getNickName())
+                .authorProfileImage((commentAuthor.getProfileImage() == null) ? "" : commentAuthor.getProfileImage())
+                .content(comment.getContent())
+                .likeCount(comment.getCommentLikes().size())
+                .isAuthor(isCommentAuthor)
+                .isLike(isCommentLike)
+                .createdDate(comment.getCreatedDate())
+                .build();
+
+        User feedAuthor = feed.getAuthor();
+        FeedCardResponse feedCardResponse = FeedCardResponse.builder()
+                .feedId(feed.getId())
+                .title(feed.getTitle())
+                .content(feed.getContent())
+                .likeCount(feed.getFeedLikes().size())
+                .feedImages(feed.getFeedImageUrls())
+                .author(feedAuthor.getNickName())
+                .authorProfileImage((feedAuthor.getProfileImage() == null) ? "" : feedAuthor.getProfileImage())
+                .createdDate(feed.getCreatedDate())
+                .isLike(isFeedLike)
+                .isAuthor(isFeedAuthor)
+                .commentCount(commentCount)
+                .comment(feedCommentResponse)
+                .build();
+        return feedCardResponse;
+    }
+}

--- a/src/main/java/com/shy_polarbear/server/domain/feed/dto/response/FeedCardResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/dto/response/FeedCardResponse.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.Optional;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -43,18 +44,24 @@ public class FeedCardResponse {
         private String createdDate;
     }
 
-    public static FeedCardResponse of(Feed feed, Comment comment, User user) {
-        User commentAuthor = comment.getAuthor();
-        FeedCommentResponse feedCommentResponse = FeedCommentResponse.builder()
-                .commentId(comment.getId())
-                .author(commentAuthor.getNickName())
-                .authorProfileImage((commentAuthor.getProfileImage() == null) ? "" : commentAuthor.getProfileImage())
-                .content(comment.getContent())
-                .likeCount(comment.getCommentLikes().size())
-                .isAuthor(comment.isAuthor(user))
-                .isLike(comment.isLike(user))
-                .createdDate(comment.getCreatedDate())
-                .build();
+    public static FeedCardResponse of(Feed feed, Optional<Comment> commentOptional, User user) {
+        FeedCommentResponse feedCommentResponse;
+        if (commentOptional.isPresent()) {
+            Comment comment = commentOptional.get();
+            User commentAuthor = comment.getAuthor();
+            feedCommentResponse = FeedCommentResponse.builder()
+                    .commentId(comment.getId())
+                    .author(commentAuthor.getNickName())
+                    .authorProfileImage((commentAuthor.getProfileImage() == null) ? "" : commentAuthor.getProfileImage())
+                    .content(comment.getContent())
+                    .likeCount(comment.getCommentLikes().size())
+                    .isAuthor(comment.isAuthor(user))
+                    .isLike(comment.isLike(user))
+                    .createdDate(comment.getCreatedDate())
+                    .build();
+        } else {
+            feedCommentResponse = FeedCommentResponse.builder().build();
+        }
 
         User feedAuthor = feed.getAuthor();
         FeedCardResponse feedCardResponse = FeedCardResponse.builder()

--- a/src/main/java/com/shy_polarbear/server/domain/feed/model/Feed.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/model/Feed.java
@@ -88,7 +88,7 @@ public class Feed extends BaseEntity {
 
     public boolean isLike(User user) {
         return feedLikes.stream()
-                .anyMatch(feedLike -> feedLike.isUser(user));
+                .anyMatch(feedLike -> feedLike.isAuthor(user));
     }
 
     public List<String> getFeedImageUrls() {

--- a/src/main/java/com/shy_polarbear/server/domain/feed/model/FeedLike.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/model/FeedLike.java
@@ -40,7 +40,7 @@ public class FeedLike extends BaseEntity {
         return feedLike;
     }
 
-    public boolean isUser(User user) {
+    public boolean isAuthor(User user) {
         return this.user.getId().equals(user.getId());
     }
 }

--- a/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedLikeRepository.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedLikeRepository.java
@@ -8,6 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
     void deleteByUserAndFeed(User user, Feed feed);
-
     boolean existsByUserAndFeed(User user, Feed feed);
 }

--- a/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedRepository.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 
-public interface FeedRepository extends JpaRepository<Feed, Long> {
+public interface FeedRepository extends JpaRepository<Feed, Long>, FeedRepositoryCustom {
     Slice<Feed> findByIdLessThanAndAuthorOrderByIdDesc(Long id, User author, Pageable pageable);
 
     Slice<Feed> findByCommentsAuthorAndCommentsIdLessThanOrderByCommentsIdDesc(User author, Long commentId, Pageable pageable);

--- a/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedRepositoryCustom.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedRepositoryCustom.java
@@ -1,10 +1,7 @@
 package com.shy_polarbear.server.domain.feed.repository;
 
 import com.shy_polarbear.server.domain.feed.model.Feed;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-
-import java.time.LocalDateTime;
 
 public interface FeedRepositoryCustom {
 
@@ -12,6 +9,6 @@ public interface FeedRepositoryCustom {
 
     Slice<Feed> findBestFeeds(Long lastFeedId, int minFeedLikeCount, int limit);
 
-    Slice<Feed> findPopularFeedsWithinEarliestDate(Long lastFeedId, LocalDateTime earliestDate, int limit);
+    Slice<Feed> findRecentBestFeeds(Long lastFeedId, String earliestDate, int limit);
 
 }

--- a/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedRepositoryCustom.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedRepositoryCustom.java
@@ -1,0 +1,17 @@
+package com.shy_polarbear.server.domain.feed.repository;
+
+import com.shy_polarbear.server.domain.feed.model.Feed;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import java.time.LocalDateTime;
+
+public interface FeedRepositoryCustom {
+
+    Slice<Feed> findRecentFeeds(Long lastFeedId, int limit);
+
+    Slice<Feed> findBestFeeds(Long lastFeedId, int minFeedLikeCount, int limit);
+
+    Slice<Feed> findPopularFeedsWithinEarliestDate(Long lastFeedId, LocalDateTime earliestDate, int limit);
+
+}

--- a/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedRepositoryImpl.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedRepositoryImpl.java
@@ -1,22 +1,15 @@
 package com.shy_polarbear.server.domain.feed.repository;
 
-import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.shy_polarbear.server.domain.feed.model.Feed;
-import com.shy_polarbear.server.global.common.constants.BusinessLogicConstants;
 import com.shy_polarbear.server.global.common.util.CustomSliceExecutionUtils;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.Optional;
 
 import static com.shy_polarbear.server.domain.feed.model.QFeed.*;
 

--- a/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedRepositoryImpl.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedRepositoryImpl.java
@@ -1,0 +1,71 @@
+package com.shy_polarbear.server.domain.feed.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.shy_polarbear.server.domain.feed.model.Feed;
+import com.shy_polarbear.server.global.common.constants.BusinessLogicConstants;
+import com.shy_polarbear.server.global.common.util.CustomSliceExecutionUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static com.shy_polarbear.server.domain.feed.model.QFeed.*;
+
+@Repository
+@RequiredArgsConstructor
+public class FeedRepositoryImpl implements FeedRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<Feed> findRecentFeeds(Long lastFeedId, int limit) {
+        JPAQuery<Feed> query = queryFactory
+                .selectFrom(feed)
+                .where(checkLastFeedId(lastFeedId))
+                .orderBy(feed.id.desc())
+                .limit(CustomSliceExecutionUtils.buildSliceLimit(limit));
+        return CustomSliceExecutionUtils.getSlice(query.fetch(), limit);
+    }
+
+    @Override
+    public Slice<Feed> findBestFeeds(Long lastFeedId, int minFeedLikeCount, int limit) {
+        JPAQuery<Feed> query = queryFactory
+                .selectFrom(feed)
+                .where(
+                        checkLastFeedId(lastFeedId),
+                        feed.feedLikes.size().goe(minFeedLikeCount)
+                )
+                .orderBy(feed.feedLikes.size().desc())
+                .limit(CustomSliceExecutionUtils.buildSliceLimit(limit));
+        return CustomSliceExecutionUtils.getSlice(query.fetch(), limit);
+    }
+
+    @Override
+    public Slice<Feed> findPopularFeedsWithinEarliestDate(Long lastFeedId, LocalDateTime earliestDate,int limit) {
+        //SELECT f
+        //FROM feed
+        //where id<lastFeedId
+        //and 작성시점>=현재-7일전
+        //ORDER BY 좋아요개수 DESC
+        //LIMIT ?
+
+        JPAQuery<Feed> query = queryFactory
+                .selectFrom(feed)
+                .where(
+                        checkLastFeedId(lastFeedId)
+                )
+                .orderBy(feed.feedLikes.size().desc())
+                .limit(CustomSliceExecutionUtils.buildSliceLimit(limit));
+        return CustomSliceExecutionUtils.getSlice(query.fetch(), limit);
+    }
+
+    private BooleanExpression checkLastFeedId(Long lastFeedId) {
+        if (lastFeedId == null || lastFeedId == 0) return null;
+        else return feed.id.lt(lastFeedId);
+    }
+}

--- a/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedRepositoryImpl.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedRepositoryImpl.java
@@ -9,16 +9,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
-import java.time.format.DateTimeFormatter;
-
 import static com.shy_polarbear.server.domain.feed.model.QFeed.*;
 
 @Repository
 @RequiredArgsConstructor
 public class FeedRepositoryImpl implements FeedRepositoryCustom {
     private final JPAQueryFactory queryFactory;
-    private static DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
 
     @Override
     public Slice<Feed> findRecentFeeds(Long lastFeedId, int limit) {

--- a/src/main/java/com/shy_polarbear/server/domain/feed/service/FeedService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/service/FeedService.java
@@ -1,5 +1,6 @@
 package com.shy_polarbear.server.domain.feed.service;
 
+import com.shy_polarbear.server.domain.comment.repository.CommentRepository;
 import com.shy_polarbear.server.domain.feed.dto.request.CreateFeedRequest;
 import com.shy_polarbear.server.domain.feed.dto.request.UpdateFeedRequest;
 import com.shy_polarbear.server.domain.feed.dto.response.*;
@@ -19,10 +20,8 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 @Service
@@ -33,6 +32,7 @@ public class FeedService {
     private final FeedRepository feedRepository;
     private final ImageService imageService;
     private final FeedLikeRepository feedLikeRepository;
+    private final CommentRepository commentRepository;
     private static DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     public CreateFeedResponse createFeed(CreateFeedRequest createFeedRequest, User user) {
@@ -99,21 +99,25 @@ public class FeedService {
         }
     }
 
-    public PageResponse<FeedCardResponse> findAllFeeds(String sort, Long lastFeedId, int limit) {
+    public PageResponse<FeedCardResponse> findAllFeeds(String sort, Long lastFeedId, int limit, User user) {
+        //정렬 기준에 따라 피드 엔티티 가져오기
         FeedSort feedSort = FeedSort.toEnum(sort);
-
+        Slice<Feed> feeds;
         switch (feedSort) {
             case BEST:
-                findBestFeeds(lastFeedId, limit);
+                feeds = findBestFeeds(lastFeedId, limit);
                 break;
             case RECENT:
-                findRecentFeeds(lastFeedId, limit);
+                feeds = findRecentFeeds(lastFeedId, limit);
                 break;
             case RECENT_BEST:
-                findRecentBestFeeds(lastFeedId, limit);
+                feeds = findRecentBestFeeds(lastFeedId, limit);
                 break;
         }
 
+        // 베스트 댓글 or 최신 댓글 가져오기
+
+        //DTO로 반환
         return null;
     }
 

--- a/src/main/java/com/shy_polarbear/server/domain/feed/service/FeedService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/service/FeedService.java
@@ -116,9 +116,8 @@ public class FeedService {
         }
 
         // 베스트 댓글 or 최신 댓글 가져오기, DTO로 반환
-        Slice<FeedCardResponse> feedCardResponse = (Slice<FeedCardResponse>) feeds.stream()
-                .map(feed -> FeedCardResponse.of(feed, commentRepository.findBestComment(feed), user));
-        return PageResponse.of(feedCardResponse, feedCardResponse.stream().count());
+        Slice<FeedCardResponse> feedCardResponses = feeds.map(feed -> FeedCardResponse.of(feed, commentRepository.findBestComment(feed), user));
+        return PageResponse.of(feedCardResponses, feedCardResponses.stream().count());
     }
 
     private Slice<Feed> findBestFeeds(Long lastFeedId, int limit) {

--- a/src/main/java/com/shy_polarbear/server/domain/feed/service/FeedService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/service/FeedService.java
@@ -102,7 +102,7 @@ public class FeedService {
     public PageResponse<FeedCardResponse> findAllFeeds(String sort, Long lastFeedId, int limit, User user) {
         //정렬 기준에 따라 피드 엔티티 가져오기
         FeedSort feedSort = FeedSort.toEnum(sort);
-        Slice<Feed> feeds;
+        Slice<Feed> feeds = null;
         switch (feedSort) {
             case BEST:
                 feeds = findBestFeeds(lastFeedId, limit);
@@ -115,10 +115,10 @@ public class FeedService {
                 break;
         }
 
-        // 베스트 댓글 or 최신 댓글 가져오기
-
-        //DTO로 반환
-        return null;
+        // 베스트 댓글 or 최신 댓글 가져오기, DTO로 반환
+        Slice<FeedCardResponse> feedCardResponse = (Slice<FeedCardResponse>) feeds.stream()
+                .map(feed -> FeedCardResponse.of(feed, commentRepository.findBestComment(feed), user));
+        return PageResponse.of(feedCardResponse, feedCardResponse.stream().count());
     }
 
     private Slice<Feed> findBestFeeds(Long lastFeedId, int limit) {

--- a/src/main/java/com/shy_polarbear/server/domain/feed/service/FeedSort.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/service/FeedSort.java
@@ -1,0 +1,31 @@
+package com.shy_polarbear.server.domain.feed.service;
+
+import com.shy_polarbear.server.domain.quiz.model.OXChoice;
+import com.shy_polarbear.server.global.common.util.EnumModel;
+import com.shy_polarbear.server.global.exception.ExceptionStatus;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum FeedSort implements EnumModel<String> {
+    BEST("best"), RECENT("recent"), RECENT_BEST("recentBest");
+    private final String value;
+
+    @Override
+    public String getKey() {
+        return this.name();
+    }
+
+    @Override
+    public String getValue() {
+        return this.value;
+    }
+
+    public static FeedSort toEnum(String stringValue) {
+        return switch (stringValue) {
+            case "best" -> BEST;
+            case "recent" -> RECENT;
+            case "recentBest" -> RECENT_BEST;
+            default -> throw new RuntimeException(ExceptionStatus.SERVER_ERROR.getMessage());
+        };
+    }
+}

--- a/src/main/java/com/shy_polarbear/server/global/common/constants/BusinessLogicConstants.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/constants/BusinessLogicConstants.java
@@ -11,5 +11,7 @@ public abstract class BusinessLogicConstants {
     /** 피드 **/
     public static final int MAX_IMAGES_COUNT = 5;
     public static final int BEST_FEED_MIN_LIKE_COUNT = 50;
+    public static final String FEED_LIMIT_PARAM_DEFAULT_VALUE = "10";
+    public static final int RECENT_BEST_FEED_DAY_LIMIT = 7;
 
 }

--- a/src/main/java/com/shy_polarbear/server/global/common/constants/BusinessLogicConstants.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/constants/BusinessLogicConstants.java
@@ -10,5 +10,6 @@ public abstract class BusinessLogicConstants {
 
     /** 피드 **/
     public static final int MAX_IMAGES_COUNT = 5;
+    public static final int BEST_FEED_MIN_LIKE_COUNT = 50;
 
 }

--- a/src/main/java/com/shy_polarbear/server/global/common/dummy/FeedInitializer.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/dummy/FeedInitializer.java
@@ -2,6 +2,7 @@ package com.shy_polarbear.server.global.common.dummy;
 
 import com.shy_polarbear.server.domain.feed.model.Feed;
 import com.shy_polarbear.server.domain.feed.model.FeedImage;
+import com.shy_polarbear.server.domain.feed.model.FeedLike;
 import com.shy_polarbear.server.domain.feed.repository.FeedRepository;
 import com.shy_polarbear.server.domain.user.exception.UserException;
 import com.shy_polarbear.server.domain.user.model.User;
@@ -43,9 +44,13 @@ public class FeedInitializer {
             log.info("더미 피드 10개를 생성합니다.");
             for (int i = 0; i < 10; i++) {
                 List<String> feedUrls = new ArrayList<>();
-                feedUrls.add("테스트 사진");
+                feedUrls.add("테스트 사진1");
+                feedUrls.add("테스트 사진2");
                 List<FeedImage> feedImages = FeedImage.createFeedImages(feedUrls);
                 Feed feed = Feed.createFeed("제목" + i, "", feedImages, user);
+                for (int j = 0; j < i; j++) {
+                    FeedLike.createFeedLike(feed, user);
+                }
                 feedRepository.save(feed);
             }
         }


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 전체 피드 조회

🌱 PR 포인트
- fetch join을 하려고 했는데 시간이 걸릴 것 같아서 이후에 리팩토링 하겠습니다^_ㅠ 
- 전체 피드 조회할 때 베스트댓글 조회를 해야 해서 댓글 코드가 추가 되었습니다!
- 베스트 피드 조회를 위해 더미피드 좋아요 수를 변경했습니다~
- 만약 피드에 댓글이 하나도 없다면, 댓글 객체의 필드는 null로 내려주고 있습니다 (빈값으로 줄 수도 있지만.. comment id 가 숫자라 뭘 채워야 할 지 고민이네요..)

## 📸 스크린샷
|스크린샷|
|:--:|
|![image](https://github.com/ShyPolarBear/Server/assets/81086966/01592677-6352-4173-87f6-1226ec1e4988)|

## 📮 관련 이슈
- Resolved: #53 
