### PR TITLE
fix: 퀴즈 제출 시간초과 로직 추가

### DIFF
--- a/src/main/java/com/shy_polarbear/server/domain/point/service/PointService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/point/service/PointService.java
@@ -28,4 +28,8 @@ public class PointService {
             return PointType.NOT_SOLVE_QUIZ.getValue();
         }
     }
+
+    public int calculateQuizSubmissionTimeout() {
+        return PointType.NOT_SOLVE_QUIZ.getValue();
+    }
 }

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/dto/request/MultipleChoiceQuizScoreRequest.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/dto/request/MultipleChoiceQuizScoreRequest.java
@@ -11,6 +11,8 @@ import javax.validation.constraints.NotNull;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MultipleChoiceQuizScoreRequest {
-        @NotNull
         private Long answerId;
+
+        @NotNull
+        private Boolean isTimeout;
 }

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/dto/request/OXQuizScoreRequest.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/dto/request/OXQuizScoreRequest.java
@@ -4,14 +4,16 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class OXQuizScoreRequest {
-    @NotBlank
     @Size(max = 1)
     private String answer;
+
+    @NotNull
+    private Boolean isTimeout;
 }

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/dto/response/MultipleChoiceQuizScoreResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/dto/response/MultipleChoiceQuizScoreResponse.java
@@ -29,5 +29,20 @@ public record MultipleChoiceQuizScoreResponse(
                 .point(pointValue)
                 .build();
     }
+
+    public static MultipleChoiceQuizScoreResponse ofTimeout(
+            MultipleChoiceQuiz quiz,
+            int sequence,
+            MultipleChoice answer,
+            int pointValue
+    ) {
+        return MultipleChoiceQuizScoreResponse.builder()
+                .quizId(quiz.getId())
+                .correctAnswer(String.format(ANSWER_FORMAT, sequence, answer.getContent()))
+                .explanation(quiz.getExplanation())
+                .isCorrect(false)
+                .point(pointValue)
+                .build();
+    }
 }
 

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/dto/response/OXQuizScoreResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/dto/response/OXQuizScoreResponse.java
@@ -20,4 +20,13 @@ public record OXQuizScoreResponse(
                 .point(pointValue)
                 .build();
     }
-}
+
+    public static OXQuizScoreResponse ofTimeout(OXQuiz oxQuiz, int pointValue) {
+        return OXQuizScoreResponse.builder()
+                .quizId(oxQuiz.getId())
+                .correctAnswer(oxQuiz.getAnswer().getValue())
+                .explanation(oxQuiz.getExplanation())
+                .isCorrect(false)
+                .point(pointValue)
+                .build();
+    }}

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/service/QuizService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/service/QuizService.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 
@@ -76,13 +77,20 @@ public class QuizService {
         OXQuiz oxQuiz = oxQuizRepository.findById(quizId)
                 .orElseThrow(() -> new QuizException(ExceptionStatus.NOT_FOUND_QUIZ));
 
-        OXChoice submittedChoice = OXChoice.toEnum(request.getAnswer());
-        boolean isCorrect = submittedChoice.equals(oxQuiz.getAnswer()); // 제출된 답안과 실제 답 비교
-        userQuizRepository.save(UserQuiz.createUserOXQuiz(user, oxQuiz, isCorrect, submittedChoice));
+        if (request.getIsTimeout()) {   // 시간초과: 오답 처리
+            int pointValue = pointService.calculateQuizSubmissionTimeout();
+            return OXQuizScoreResponse.ofTimeout(oxQuiz, pointValue);
+        } else if (Objects.isNull(request.getAnswer())) { // 시간초과되지 않았는데 선택지가 null: 클라이언트 에러
+            throw new QuizException(ExceptionStatus.QUIZ_SUBMISSION_NULL_CLIENT_ERROR);
+        } else {
+            OXChoice submittedChoice = OXChoice.toEnum(request.getAnswer());
+            boolean isCorrect = submittedChoice.equals(oxQuiz.getAnswer()); // 제출된 답안과 실제 답 비교
 
-        int pointValue = pointService.calculateQuizSubmissionPoint(isCorrect, user);    // 포인트 처리
+            userQuizRepository.save(UserQuiz.createUserOXQuiz(user, oxQuiz, isCorrect, submittedChoice));
 
-        return OXQuizScoreResponse.of(oxQuiz, isCorrect, pointValue);
+            int pointValue = pointService.calculateQuizSubmissionPoint(isCorrect, user);    // 포인트 처리
+            return OXQuizScoreResponse.of(oxQuiz, isCorrect, pointValue);
+        }
     }
 
     // 객관식 퀴즈 제출 채점
@@ -93,18 +101,25 @@ public class QuizService {
                 .orElseThrow(() -> new QuizException(ExceptionStatus.NOT_FOUND_QUIZ));
         List<MultipleChoice> multipleChoiceList = multipleChoiceRepository.findAllByMultipleChoiceQuizId(quizId);
 
-        MultipleChoice submittedChoice = multipleChoiceList.stream().filter(it -> it.getId().equals(request.getAnswerId())).findFirst()
-                .orElseThrow(() -> new QuizException(ExceptionStatus.NOT_FOUND_CHOICE));
         MultipleChoice answer = multipleChoiceList.stream().filter(MultipleChoice::isAnswer).findFirst()
                 .orElseThrow(() -> new QuizException(ExceptionStatus.SERVER_ERROR));    // 답이 없는 퀴즈는 서버쪽 오류
-
-        boolean isCorrect = submittedChoice.equals(answer); // 제출된 답안과 실제 답 비교
-        userQuizRepository.save(UserQuiz.createUserMultipleChoiceQuiz(user, multipleChoiceQuiz, isCorrect, submittedChoice));
-
-        int pointValue = pointService.calculateQuizSubmissionPoint(isCorrect, user);    // 포인트 처리
         int sequence = multipleChoiceList.indexOf(answer) + 1;// 정답 선택지의 순서
 
-        return MultipleChoiceQuizScoreResponse.of(multipleChoiceQuiz, sequence, answer, isCorrect, pointValue);
+        if (request.getIsTimeout()) {   // 시간초과: 오답 처리
+            int pointValue = pointService.calculateQuizSubmissionTimeout();
+            return MultipleChoiceQuizScoreResponse.ofTimeout(multipleChoiceQuiz, sequence, answer, pointValue);
+        } else if (Objects.isNull(request.getAnswerId())) { // 시간초과되지 않았는데 선택지가 null: 클라이언트 에러
+            throw new QuizException(ExceptionStatus.QUIZ_SUBMISSION_NULL_CLIENT_ERROR);
+        } else {
+            MultipleChoice submittedChoice = multipleChoiceList.stream().filter(it -> it.getId().equals(request.getAnswerId())).findFirst()
+                    .orElseThrow(() -> new QuizException(ExceptionStatus.NOT_FOUND_CHOICE));
+
+            boolean isCorrect = submittedChoice.equals(answer); // 제출된 답안과 실제 답 비교
+            userQuizRepository.save(UserQuiz.createUserMultipleChoiceQuiz(user, multipleChoiceQuiz, isCorrect, submittedChoice));
+
+            int pointValue = pointService.calculateQuizSubmissionPoint(isCorrect, user);    // 포인트 처리
+            return MultipleChoiceQuizScoreResponse.of(multipleChoiceQuiz, sequence, answer, isCorrect, pointValue);
+        }
     }
 
     // 퀴즈 유형에 따른 분기처리

--- a/src/main/java/com/shy_polarbear/server/global/exception/ExceptionStatus.java
+++ b/src/main/java/com/shy_polarbear/server/global/exception/ExceptionStatus.java
@@ -38,6 +38,7 @@ public enum ExceptionStatus {
     NOT_FOUND_QUIZ(404, 3001, "존재하지 않는 퀴즈입니다."),
     NOT_FOUND_CHOICE(404, 3010, "존재하지 않는 선택지입니다."),
     NO_MORE_DAILY_QUIZ(404,3002,"데일리 퀴즈가 더 이상 존재하지 않습니다."),
+    QUIZ_SUBMISSION_NULL_CLIENT_ERROR(400,3003,"클라이언트 오류: 제출된 선택지가 NULL 입니다."),
     ;
 
 


### PR DESCRIPTION
## 📌 PR 요약

퀴즈 제출시 시간초과 로직에 대한 고려를 안 하고 있었고, isTimeout 필드 추가 및 answer 필드를 nullable하도록 변경했습니다.


![image](https://github.com/ShyPolarBear/Server/assets/72124326/77fd7003-620d-4eff-b0ee-9747c3c191d6)

🌱 작업한 내용
- DTO: isTimeout 필드 추가, answer 필드 `@NotNull` 제거
- 서비스: 시간 초과 관련 분기 처리가 추가됐습니다.

🌱 PR 포인트
-

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|

시간초과된 경우 : answer 필드가 null이어도 상관 없음
![image](https://github.com/ShyPolarBear/Server/assets/72124326/1c2fee75-4a1a-486f-8876-684e02d2e234)

시간초과가 되지 않았는데 answer 필드가 null인 경우 : 클라이언트 에러
![image](https://github.com/ShyPolarBear/Server/assets/72124326/fed23280-3a84-4fd3-a3db-ea05accab25e)

## 📮 관련 이슈
- Resolved: #이슈번호
