### PR TITLE
fix: 커스텀커서로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
 	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
 	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
 
+	//p6spy
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.1'
+
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedLikeRepository.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedLikeRepository.java
@@ -6,7 +6,8 @@ import com.shy_polarbear.server.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
-public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
+public interface FeedLikeRepository extends JpaRepository<FeedLike, Long>, FeedLikeRepositoryCustom {
     void deleteByUserAndFeed(User user, Feed feed);
     boolean existsByUserAndFeed(User user, Feed feed);
+
 }

--- a/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedLikeRepositoryCustom.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedLikeRepositoryCustom.java
@@ -1,0 +1,5 @@
+package com.shy_polarbear.server.domain.feed.repository;
+
+public interface FeedLikeRepositoryCustom {
+    Long countFeedLikes(Long feedId);
+}

--- a/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedLikeRepositoryImpl.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedLikeRepositoryImpl.java
@@ -1,0 +1,22 @@
+package com.shy_polarbear.server.domain.feed.repository;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import static com.shy_polarbear.server.domain.feed.model.QFeedLike.*;
+
+@Repository
+@RequiredArgsConstructor
+public class FeedLikeRepositoryImpl implements FeedLikeRepositoryCustom{
+    private final JPAQueryFactory queryFactory;
+    @Override
+    public Long countFeedLikes(Long feedId) {
+        JPAQuery<Long> query = queryFactory
+                .select(feedLike.count())
+                .from(feedLike)
+                .where(feedLike.feed.id.eq(feedId));
+        return query.fetchOne();
+    }
+}

--- a/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedRepositoryCustom.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedRepositoryCustom.java
@@ -7,8 +7,8 @@ public interface FeedRepositoryCustom {
 
     Slice<Feed> findRecentFeeds(Long lastFeedId, int limit);
 
-    Slice<Feed> findBestFeeds(Long lastFeedId, int minFeedLikeCount, int limit);
+    Slice<Feed> findBestFeeds(String cursor, int minFeedLikeCount, int limit);
 
-    Slice<Feed> findRecentBestFeeds(Long lastFeedId, String earliestDate, int limit);
+    Slice<Feed> findRecentBestFeeds(String cursor, String earliestDate, int limit);
 
 }

--- a/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedRepositoryImpl.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.shy_polarbear.server.domain.feed.repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.StringExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.shy_polarbear.server.domain.feed.model.Feed;
@@ -28,36 +29,51 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
     }
 
     @Override
-    public Slice<Feed> findBestFeeds(Long lastFeedId, int minFeedLikeCount, int limit) {
+    public Slice<Feed> findBestFeeds(String cursor, int minFeedLikeCount, int limit) {
         //베스트 : 전체 기간 중 좋아요 개수가 50개 이상인 피드를 보여준다
         JPAQuery<Feed> query = queryFactory
                 .selectFrom(feed)
                 .where(
-                        lessThanLastFeedId(lastFeedId),
-                        feed.feedLikes.size().goe(minFeedLikeCount)
+                        feed.feedLikes.size().goe(minFeedLikeCount),
+                        lessThanCustomCursor(cursor)
                 )
-                .orderBy(feed.feedLikes.size().desc())
+                .orderBy(
+                        feed.feedLikes.size().desc(),
+                        feed.id.desc()
+                )
                 .limit(CustomSliceExecutionUtils.buildSliceLimit(limit));
         return CustomSliceExecutionUtils.getSlice(query.fetch(), limit);
     }
 
     @Override
-    public Slice<Feed> findRecentBestFeeds(Long lastFeedId, String earliestDate, int limit) {
+    public Slice<Feed> findRecentBestFeeds(String cursor, String earliestDate, int limit) {
         //최근 인기순 : 7일 내 작성된 피드를 좋아요 순으로 보여준다.
         JPAQuery<Feed> query = queryFactory
                 .selectFrom(feed)
                 .where(
-                        lessThanLastFeedId(lastFeedId),
-                        feed.createdDate.goe(earliestDate)
+                        feed.createdDate.goe(earliestDate),
+                        lessThanCustomCursor(cursor)
                 )
-                .orderBy(feed.feedLikes.size().desc())
+                .orderBy(
+                        feed.feedLikes.size().desc(),
+                        feed.id.desc()
+                )
                 .limit(CustomSliceExecutionUtils.buildSliceLimit(limit));
-
         return CustomSliceExecutionUtils.getSlice(query.fetch(), limit);
     }
 
     private BooleanExpression lessThanLastFeedId(Long lastFeedId) {
         if (lastFeedId == null || lastFeedId == 0) return null;
         else return feed.id.lt(lastFeedId);
+    }
+
+    private BooleanExpression lessThanCustomCursor(String customCursor){
+        if (customCursor == null) {
+            return null;
+        }
+        return StringExpressions
+                .lpad(feed.feedLikes.size().stringValue(), 10, '0')
+                .concat(StringExpressions.lpad(feed.id.stringValue(), 19, '0'))
+                .lt(customCursor);
     }
 }

--- a/src/main/java/com/shy_polarbear/server/domain/feed/service/FeedService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/service/FeedService.java
@@ -24,6 +24,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -121,7 +122,7 @@ public class FeedService {
     }
 
     private Slice<Feed> findBestFeeds(Long lastFeedId, int limit) {
-        return feedRepository.findBestFeeds(lastFeedId, BusinessLogicConstants.BEST_FEED_MIN_LIKE_COUNT, limit);
+        return feedRepository.findBestFeeds(generateCursor(lastFeedId), BusinessLogicConstants.BEST_FEED_MIN_LIKE_COUNT, limit);
     }
 
     private Slice<Feed> findRecentFeeds(Long lastFeedId, int limit) {
@@ -132,6 +133,14 @@ public class FeedService {
         String earliestDate = LocalDateTime.now()
                 .minusDays(BusinessLogicConstants.RECENT_BEST_FEED_DAY_LIMIT)
                 .format(dateTimeFormatter);
-        return feedRepository.findRecentBestFeeds(lastFeedId, earliestDate, limit);
+        return feedRepository.findRecentBestFeeds(generateCursor(lastFeedId), earliestDate, limit);
+    }
+
+    private String generateCursor(Long lastFeedId){
+        if (lastFeedId == null) {
+            return null;
+        }
+        Long feedLikesCount = feedLikeRepository.countFeedLikes(lastFeedId);
+        return String.format("%010d", feedLikesCount) + String.format("%019d", lastFeedId);
     }
 }

--- a/src/main/java/com/shy_polarbear/server/global/common/dummy/FeedInitializer.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/dummy/FeedInitializer.java
@@ -41,14 +41,23 @@ public class FeedInitializer {
         User user = userRepository.findByProviderId(LOGIN_USER_PROVIDER_ID)
                 .orElseThrow(() -> new UserException(ExceptionStatus.NOT_FOUND_USER));
         if (feedRepository.count() == 0) {
-            log.info("더미 피드 10개를 생성합니다.");
+            log.info("더미 피드 20개를 생성합니다.");
             for (int i = 0; i < 10; i++) {
                 List<String> feedUrls = new ArrayList<>();
-                feedUrls.add("테스트 사진1");
-                feedUrls.add("테스트 사진2");
+                feedUrls.add("테스트 사진");
                 List<FeedImage> feedImages = FeedImage.createFeedImages(feedUrls);
                 Feed feed = Feed.createFeed("제목" + i, "", feedImages, user);
                 for (int j = 0; j < i; j++) {
+                    FeedLike.createFeedLike(feed, user);
+                }
+                feedRepository.save(feed);
+            }
+            for (int i = 0; i < 10; i++) {
+                List<String> feedUrls = new ArrayList<>();
+                feedUrls.add("테스트 사진");
+                List<FeedImage> feedImages = FeedImage.createFeedImages(feedUrls);
+                Feed feed = Feed.createFeed("제목" + (i + 10), "", feedImages, user);
+                for (int j = i; j > 0; j--) {
                     FeedLike.createFeedLike(feed, user);
                 }
                 feedRepository.save(feed);


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 전체 피드 조회 api 커스텀 커서 사용하게 변경 

🌱 PR 포인트
- FeedLike 카운트 쿼리 메서드 추가
- 커스텀 커서 구현 : 10자리(좋아요 개수) + 19자리(피드 아이디)
- 분기 처리를 repository로 옮기려고 했는데 그럼 repository가 너무 많은 걸(sort enum이나 비즈니스 상 변경 가능성 있는 상수, dateTimeFormatter 등) 알지 않나 해서 일단 그대로 했습니다!
- repository querydsl 코드에 중복이 많아서 중복 제거를 하려고 했으나 세 메서드(베스트, 최신순, 최근인기순)를 하나로 합치면 
where 조건절 null 체크를 해야 하고 두개만 합치는 건 직관적이지 않을 것 같아 그냥 중복을 허용했습니다..  
- 더미 피드 20개로 변경
- 베스트, 최신 인기 피드 조회 시 좋아요 개수가 같으면 최근 작성된 피드가 우위를 차지합니다~

## 📸 스크린샷
|스크린샷|
|:--:|
|![image](https://github.com/ShyPolarBear/Server/assets/81086966/f5eeabf6-c308-4adb-a42e-d1cf7a7fcd6e)|

## 📮 관련 이슈
- Resolved: #64 
