### PR TITLE
fix: 복습 퀴즈 조회 랜덤 로직으로 변경

### DIFF
--- a/src/main/java/com/shy_polarbear/server/domain/quiz/controller/QuizController.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/controller/QuizController.java
@@ -48,7 +48,7 @@ public class QuizController {
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             @RequestParam(required = false, defaultValue = BusinessLogicConstants.REVIEW_QUIZ_LIMIT_PARAM_DEFAULT_VALUE) int limit
     ) {
-        PageResponse<QuizCardResponse> pageResponse = quizService.getReviewQuizzes(principalDetails.getUser().getId(), limit);
+        PageResponse<QuizCardResponse> pageResponse = quizService.getRandomReviewQuizzes(principalDetails.getUser().getId(), limit);
         return success(pageResponse);
     }
 

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/repository/QuizRepositoryCustom.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/repository/QuizRepositoryCustom.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 public interface QuizRepositoryCustom {
     Optional<Quiz> findRecentQuizNotYetSolvedByUser(Long userId);
 
-    Slice<Quiz> findRecentQuizzesAlreadySolvedByUser(Long userId, int limit);
+    Slice<Quiz> findRandomQuizzesAlreadySolvedByUser(Long userId, int limit);
 
     Long countAllRecentQuizzesAlreadySolvedByUser(Long userId);
 }

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/repository/QuizRepositoryImpl.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/repository/QuizRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.shy_polarbear.server.domain.quiz.model.Quiz;
 import com.shy_polarbear.server.global.common.util.CustomSliceExecutionUtils;
+import com.shy_polarbear.server.global.common.util.query.CustomOrderSpecifierUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
@@ -30,10 +31,10 @@ public class QuizRepositoryImpl implements QuizRepositoryCustom {
     }
 
     @Override
-    public Slice<Quiz> findRecentQuizzesAlreadySolvedByUser(Long userId, int limit) {
+    public Slice<Quiz> findRandomQuizzesAlreadySolvedByUser(Long userId, int limit) {
         JPAQuery<Quiz> query = queryFactory.selectFrom(quiz)
                 .where(quiz.id.in(findSolvedQuizIdsSubQuery(userId)))
-                .orderBy(quiz.id.desc())   // 최신순
+                .orderBy(CustomOrderSpecifierUtils.makeRandom())   // 랜덤 정렬
                 .limit(CustomSliceExecutionUtils.buildSliceLimit(limit));
 
         return CustomSliceExecutionUtils.getSlice(query.fetch(), limit);

--- a/src/main/java/com/shy_polarbear/server/domain/quiz/service/QuizService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/quiz/service/QuizService.java
@@ -48,10 +48,10 @@ public class QuizService {
         return buildQuizCardResponseFromQuiz(quiz);
     }
 
-    // 복습 퀴즈 조회 : 최신순으로 5개
-    public PageResponse<QuizCardResponse> getReviewQuizzes(Long currentUserId, int limit) {
+    // 복습 퀴즈 조회 : 랜덤으로 5개
+    public PageResponse<QuizCardResponse> getRandomReviewQuizzes(Long currentUserId, int limit) {
         Slice<QuizCardResponse> result = quizRepository
-                .findRecentQuizzesAlreadySolvedByUser(currentUserId, limit)
+                .findRandomQuizzesAlreadySolvedByUser(currentUserId, limit)
                 .map(this::buildQuizCardResponseFromQuiz);
 
         Long count = quizRepository.countAllRecentQuizzesAlreadySolvedByUser(currentUserId);

--- a/src/main/java/com/shy_polarbear/server/global/common/util/query/CustomOrderSpecifierUtils.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/util/query/CustomOrderSpecifierUtils.java
@@ -1,0 +1,11 @@
+package com.shy_polarbear.server.global.common.util.query;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.Expressions;
+
+public class CustomOrderSpecifierUtils {
+    // TODO: ORDER BY에 INDEX를 활용할 수 없어서 비효율적으로 동작 -> 랜덤 쿼리 튜닝 https://leezzangmin.tistory.com/28
+    public static OrderSpecifier<Double> makeRandom() { // Mysql RAND 함수를 지원하지 않아서 만든 함수
+        return Expressions.numberTemplate(Double.class, "function('rand')").asc();
+    }
+}


### PR DESCRIPTION
## 📌 PR 요약
복습 퀴즈 조회 랜덤 로직으로 변경

🌱 작업한 내용
- 쿼리문을 랜덤 조회로 변경
- 랜덤 유틸 생성 : 기본적으로 JPA Hibernate 에서 mysql 랜덤 함수를 지원하지 않아서 만들었습니다
참고 : https://eclipse4j.tistory.com/367  https://dazbee.tistory.com/64

랜덤인지라 인덱스 정렬을 못해서 성능이 떨어진다고 하네요
이 부분 최적화를 고민해봤지만 지금은 방법이 떠오르지 않네요 :smiling_face_with_tear: 

🌱 PR 포인트
-

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|

요청할때마다 매번 다르게 정렬되는 모습:

![image](https://github.com/ShyPolarBear/Server/assets/72124326/401e2969-3b78-4fa6-a189-59f942b7c1a4)
![image](https://github.com/ShyPolarBear/Server/assets/72124326/e1222dda-f24a-43fb-92d6-3bdb07ac93cf)
![image](https://github.com/ShyPolarBear/Server/assets/72124326/43d7a4e2-393f-4df2-a6b9-adc9f0312fdc)

## 📮 관련 이슈
- Resolved: #이슈번호
