### PR TITLE
Fix/ 피드 작성 시 피드이미지 없는 경우 해결

### DIFF
--- a/src/main/java/com/shy_polarbear/server/domain/feed/model/Feed.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/model/Feed.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -15,6 +16,7 @@ import java.util.List;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Slf4j
 public class Feed extends BaseEntity {
 
     @Id
@@ -37,33 +39,28 @@ public class Feed extends BaseEntity {
     private List<Comment> comments = new ArrayList<>();
 
     @Builder
-    private Feed(String title, String content, List<FeedImage> feedImages, User author) {
+    private Feed(String title, String content, User author) {
         this.title = title;
         this.content = content;
-        this.feedImages.addAll(feedImages);
         this.author = author;
     }
 
     public static Feed createFeed(String title, String content, List<FeedImage> feedImages, User author) {
+        Feed feed = Feed.builder()
+                .title(title)
+                .content(content)
+                .author(author)
+                .build();
         if (feedImages == null) {
-            return Feed.builder()
-                    .title(title)
-                    .content(content)
-                    .author(author)
-                    .build();
+            return feed;
         } else {
-            Feed feed = Feed.builder()
-                    .title(title)
-                    .content(content)
-                    .feedImages(feedImages)
-                    .author(author)
-                    .build();
             assignFeedToFeedImages(feedImages, feed);
             return feed;
         }
     }
 
     private static void assignFeedToFeedImages(List<FeedImage> feedImages, Feed feed) {
+        feed.feedImages.addAll(feedImages);
         feedImages.stream()
                 .forEach(feedImage -> feedImage.assignFeed(feed));
     }
@@ -78,7 +75,6 @@ public class Feed extends BaseEntity {
         this.feedImages.clear();
         if (feedImages != null) {
             assignFeedToFeedImages(feedImages, this);
-            this.feedImages.addAll(feedImages);
         }
     }
 

--- a/src/main/java/com/shy_polarbear/server/domain/feed/service/FeedService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/service/FeedService.java
@@ -13,6 +13,7 @@ import com.shy_polarbear.server.domain.images.service.ImageService;
 import com.shy_polarbear.server.domain.user.model.User;
 import com.shy_polarbear.server.global.exception.ExceptionStatus;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -21,6 +22,7 @@ import java.util.List;
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class FeedService {
 
     private final FeedRepository feedRepository;

--- a/src/main/java/com/shy_polarbear/server/domain/images/service/S3FileService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/images/service/S3FileService.java
@@ -36,7 +36,6 @@ public class S3FileService {
 
     void delete(String s3DeleteFilePath) {
         try {
-            System.out.println("s3DeleteFilePath = " + s3DeleteFilePath);
             amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, s3DeleteFilePath));
         } catch (Exception e) {
             throw new ImageException(ExceptionStatus.FAIL_DELETE_IMAGES);


### PR DESCRIPTION
## 📌 PR 요약

🌱 이슈
- 피드 작성 시 이미지가 아예 없는 경우 피드 객체 생성할 때 NullPoinetException 발생
- 생성자 안에 `feed.feedImages.addAll(feedImages);` 이 코드가 있어서 피드이미지 가 없을 시 문제가 발생한 것 같습니다!

🌱 PR 포인트
- 피드 이미지에 피드를 할당하는 assignFeedToFeedImages()에서 피드에 피드 이미지를 할당하는 코드를 추가했습니다.

## 📸 스크린샷
|스크린샷|
|:--:|
|![image](https://github.com/ShyPolarBear/Server/assets/81086966/7157b4e2-48df-4023-84d3-37a78da26036)|

