### PR TITLE
refactor: ControllerAdvice 런타임 에러 스택 출력

### DIFF
--- a/src/main/java/com/shy_polarbear/server/global/exception/ControllerAdvice.java
+++ b/src/main/java/com/shy_polarbear/server/global/exception/ControllerAdvice.java
@@ -5,13 +5,11 @@ import com.shy_polarbear.server.global.common.dto.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.validation.BindException;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -52,6 +50,7 @@ public class ControllerAdvice {
         String message = ExceptionStatus.SERVER_ERROR.getMessage();
 
         log.warn("{}({}) - {}", ex.getClass().getSimpleName(), code, ex.getMessage());
+        ex.printStackTrace();
         return ResponseEntity.status(httpCode)
                 .body(ApiResponse.error(code, message));
     }


### PR DESCRIPTION
## 📌 PR 요약
런타임 에러 발생했을 때 ControllerAdvice에서 채가버려서 스택 트레이스가 안 찍히더라구요
그래서 출력되게 했습니다!

🌱 작업한 내용
- unused import statement 제거

🌱 PR 포인트
-

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|

## 📮 관련 이슈
- Resolved: #이슈번호
