### PR TITLE
refactor: 이미지 업로드 api 인증 제외

### DIFF
--- a/spy.log
+++ b/spy.log
@@ -1,0 +1,17 @@
+1694416365593|1|statement|connection 34|url jdbc:h2:mem:bf1e32b7-b24d-4247-addc-6ec86a7fbc99|drop table if exists blocked_user CASCADE |drop table if exists blocked_user CASCADE 
+1694416365596|0|statement|connection 34|url jdbc:h2:mem:bf1e32b7-b24d-4247-addc-6ec86a7fbc99|drop table if exists comment CASCADE |drop table if exists comment CASCADE 
+1694416365600|0|statement|connection 34|url jdbc:h2:mem:bf1e32b7-b24d-4247-addc-6ec86a7fbc99|drop table if exists comment_like CASCADE |drop table if exists comment_like CASCADE 
+1694416365601|0|statement|connection 34|url jdbc:h2:mem:bf1e32b7-b24d-4247-addc-6ec86a7fbc99|drop table if exists dormant_user CASCADE |drop table if exists dormant_user CASCADE 
+1694416365604|2|statement|connection 34|url jdbc:h2:mem:bf1e32b7-b24d-4247-addc-6ec86a7fbc99|drop table if exists feed CASCADE |drop table if exists feed CASCADE 
+1694416365604|0|statement|connection 34|url jdbc:h2:mem:bf1e32b7-b24d-4247-addc-6ec86a7fbc99|drop table if exists feed_image CASCADE |drop table if exists feed_image CASCADE 
+1694416365605|0|statement|connection 34|url jdbc:h2:mem:bf1e32b7-b24d-4247-addc-6ec86a7fbc99|drop table if exists feed_like CASCADE |drop table if exists feed_like CASCADE 
+1694416365606|0|statement|connection 34|url jdbc:h2:mem:bf1e32b7-b24d-4247-addc-6ec86a7fbc99|drop table if exists multiple_choice CASCADE |drop table if exists multiple_choice CASCADE 
+1694416365607|0|statement|connection 34|url jdbc:h2:mem:bf1e32b7-b24d-4247-addc-6ec86a7fbc99|drop table if exists notification CASCADE |drop table if exists notification CASCADE 
+1694416365607|0|statement|connection 34|url jdbc:h2:mem:bf1e32b7-b24d-4247-addc-6ec86a7fbc99|drop table if exists point CASCADE |drop table if exists point CASCADE 
+1694416365608|0|statement|connection 34|url jdbc:h2:mem:bf1e32b7-b24d-4247-addc-6ec86a7fbc99|drop table if exists prize CASCADE |drop table if exists prize CASCADE 
+1694416365608|0|statement|connection 34|url jdbc:h2:mem:bf1e32b7-b24d-4247-addc-6ec86a7fbc99|drop table if exists quiz CASCADE |drop table if exists quiz CASCADE 
+1694416365609|0|statement|connection 34|url jdbc:h2:mem:bf1e32b7-b24d-4247-addc-6ec86a7fbc99|drop table if exists refresh_token CASCADE |drop table if exists refresh_token CASCADE 
+1694416365610|0|statement|connection 34|url jdbc:h2:mem:bf1e32b7-b24d-4247-addc-6ec86a7fbc99|drop table if exists user_quiz CASCADE |drop table if exists user_quiz CASCADE 
+1694416365611|0|statement|connection 34|url jdbc:h2:mem:bf1e32b7-b24d-4247-addc-6ec86a7fbc99|drop table if exists users CASCADE |drop table if exists users CASCADE 
+1694416365612|0|statement|connection 34|url jdbc:h2:mem:bf1e32b7-b24d-4247-addc-6ec86a7fbc99|drop table if exists withdrawn_user CASCADE |drop table if exists withdrawn_user CASCADE 
+1694416365612|0|statement|connection 34|url jdbc:h2:mem:bf1e32b7-b24d-4247-addc-6ec86a7fbc99|drop sequence if exists hibernate_sequence|drop sequence if exists hibernate_sequence

--- a/src/main/java/com/shy_polarbear/server/global/auth/security/SecurityConfig.java
+++ b/src/main/java/com/shy_polarbear/server/global/auth/security/SecurityConfig.java
@@ -9,6 +9,7 @@ import com.shy_polarbear.server.global.common.constants.GlobalConstants;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -44,6 +45,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .and()
                     .authorizeRequests()
                             .antMatchers(GlobalConstants.permittedUrls).permitAll()
+                            .antMatchers(HttpMethod.POST, GlobalConstants.permittedUrlsWithPostMethod).permitAll()
                         .anyRequest().authenticated()
                 .and()
                     .logout()

--- a/src/main/java/com/shy_polarbear/server/global/common/constants/GlobalConstants.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/constants/GlobalConstants.java
@@ -12,4 +12,7 @@ public class GlobalConstants {
             "/api/health"
     };
 
+    public static String[] permittedUrlsWithPostMethod = {
+            "/api/images"
+    };
 }


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 회원가입 시 엑세스 토큰 줄 수 없으므로 이미지 업로드 api 인증 필터 안거치게 했습니다..~
- post 메서드일 때만 허락하는 Url 배열을 만들었는데 괜찮은가요^___^
- 다른 PR에 끼워 넣으려고 했는데 민규님께 빠르게 드리기 위해서 PR 날립니다~~
