### PR TITLE
[WBS-81] 댓글, 대댓글 API 구현

### DIFF
--- a/src/main/java/com/shy_polarbear/server/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/controller/CommentController.java
@@ -3,6 +3,7 @@ package com.shy_polarbear.server.domain.comment.controller;
 import com.shy_polarbear.server.domain.comment.dto.request.CommentCreateRequest;
 import com.shy_polarbear.server.domain.comment.dto.request.CommentUpdateRequest;
 import com.shy_polarbear.server.domain.comment.dto.response.CommentCreateResponse;
+import com.shy_polarbear.server.domain.comment.dto.response.CommentLikeResponse;
 import com.shy_polarbear.server.domain.comment.dto.response.CommentResponse;
 import com.shy_polarbear.server.domain.comment.dto.response.CommentUpdateResponse;
 import com.shy_polarbear.server.domain.comment.service.CommentService;
@@ -62,6 +63,14 @@ public class CommentController {
 
 
     // 댓글 좋아요 혹은 좋아요 취소
+    @PutMapping("/{commentId}/like")
+    public ApiResponse<CommentLikeResponse> likeComment(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        CommentLikeResponse response = commentService.likeComment(principalDetails.getUser().getId(), commentId);
+        return success(response);
+    }
 
 
     // 댓글 삭제

--- a/src/main/java/com/shy_polarbear/server/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/controller/CommentController.java
@@ -1,6 +1,8 @@
 package com.shy_polarbear.server.domain.comment.controller;
 
-import com.shy_polarbear.server.domain.comment.dto.CommentResponse;
+import com.shy_polarbear.server.domain.comment.dto.request.CommentCreateRequest;
+import com.shy_polarbear.server.domain.comment.dto.response.CommentCreateResponse;
+import com.shy_polarbear.server.domain.comment.dto.response.CommentResponse;
 import com.shy_polarbear.server.domain.comment.service.CommentService;
 import com.shy_polarbear.server.global.auth.security.PrincipalDetails;
 import com.shy_polarbear.server.global.common.constants.BusinessLogicConstants;
@@ -10,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 import static com.shy_polarbear.server.global.common.dto.ApiResponse.success;
 
@@ -33,6 +37,15 @@ public class CommentController {
     }
 
     // 댓글 생성
+    @PostMapping("/{feedId}")
+    public ApiResponse<CommentCreateResponse> createComment(
+            @PathVariable Long feedId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestBody @Valid CommentCreateRequest request
+    ) {
+        CommentCreateResponse response = commentService.createComment(principalDetails.getUser().getId(), feedId, request);
+        return success(response);
+    }
 
 
     // 댓글 수정

--- a/src/main/java/com/shy_polarbear/server/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/controller/CommentController.java
@@ -2,10 +2,7 @@ package com.shy_polarbear.server.domain.comment.controller;
 
 import com.shy_polarbear.server.domain.comment.dto.request.CommentCreateRequest;
 import com.shy_polarbear.server.domain.comment.dto.request.CommentUpdateRequest;
-import com.shy_polarbear.server.domain.comment.dto.response.CommentCreateResponse;
-import com.shy_polarbear.server.domain.comment.dto.response.CommentLikeResponse;
-import com.shy_polarbear.server.domain.comment.dto.response.CommentResponse;
-import com.shy_polarbear.server.domain.comment.dto.response.CommentUpdateResponse;
+import com.shy_polarbear.server.domain.comment.dto.response.*;
 import com.shy_polarbear.server.domain.comment.service.CommentService;
 import com.shy_polarbear.server.global.auth.security.PrincipalDetails;
 import com.shy_polarbear.server.global.common.constants.BusinessLogicConstants;
@@ -61,7 +58,6 @@ public class CommentController {
         return success(response);
     }
 
-
     // 댓글 좋아요 혹은 좋아요 취소
     @PutMapping("/{commentId}/like")
     public ApiResponse<CommentLikeResponse> likeComment(
@@ -72,6 +68,13 @@ public class CommentController {
         return success(response);
     }
 
-
     // 댓글 삭제
+    @DeleteMapping("/{commentId}")
+    public ApiResponse<CommentDeleteResponse> deleteComment(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        CommentDeleteResponse response = commentService.deleteComment(principalDetails.getUser().getId(), commentId);
+        return success(response);
+    }
 }

--- a/src/main/java/com/shy_polarbear/server/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/controller/CommentController.java
@@ -1,8 +1,10 @@
 package com.shy_polarbear.server.domain.comment.controller;
 
 import com.shy_polarbear.server.domain.comment.dto.request.CommentCreateRequest;
+import com.shy_polarbear.server.domain.comment.dto.request.CommentUpdateRequest;
 import com.shy_polarbear.server.domain.comment.dto.response.CommentCreateResponse;
 import com.shy_polarbear.server.domain.comment.dto.response.CommentResponse;
+import com.shy_polarbear.server.domain.comment.dto.response.CommentUpdateResponse;
 import com.shy_polarbear.server.domain.comment.service.CommentService;
 import com.shy_polarbear.server.global.auth.security.PrincipalDetails;
 import com.shy_polarbear.server.global.common.constants.BusinessLogicConstants;
@@ -47,8 +49,16 @@ public class CommentController {
         return success(response);
     }
 
-
     // 댓글 수정
+    @PutMapping("/{commentId}")
+    public ApiResponse<CommentUpdateResponse> updateComment(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestBody @Valid CommentUpdateRequest request
+    ) {
+        CommentUpdateResponse response = commentService.updateComment(principalDetails.getUser().getId(), commentId, request);
+        return success(response);
+    }
 
 
     // 댓글 좋아요 혹은 좋아요 취소

--- a/src/main/java/com/shy_polarbear/server/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/controller/CommentController.java
@@ -1,0 +1,45 @@
+package com.shy_polarbear.server.domain.comment.controller;
+
+import com.shy_polarbear.server.domain.comment.dto.CommentResponse;
+import com.shy_polarbear.server.domain.comment.service.CommentService;
+import com.shy_polarbear.server.global.auth.security.PrincipalDetails;
+import com.shy_polarbear.server.global.common.constants.BusinessLogicConstants;
+import com.shy_polarbear.server.global.common.dto.ApiResponse;
+import com.shy_polarbear.server.global.common.dto.NoCountPageResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import static com.shy_polarbear.server.global.common.dto.ApiResponse.success;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/comments")
+@RequiredArgsConstructor
+public class CommentController {
+    private final CommentService commentService;
+
+    // 댓글 리스트 조회 (무한 스크롤)
+    @GetMapping("/{feedId}")
+    public ApiResponse<NoCountPageResponse<CommentResponse>> getComments(
+            @PathVariable Long feedId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestParam(required = false) Long lastCommentId,
+            @RequestParam(required = false, defaultValue = BusinessLogicConstants.COMMENT_LIMIT_PARAM_DEFAULT_VALUE) Integer limit
+    ) {
+        NoCountPageResponse<CommentResponse> response = commentService.getComments(principalDetails.getUser().getId(), feedId, lastCommentId, limit);
+        return success(response);
+    }
+
+    // 댓글 생성
+
+
+    // 댓글 수정
+
+
+    // 댓글 좋아요 혹은 좋아요 취소
+
+
+    // 댓글 삭제
+}

--- a/src/main/java/com/shy_polarbear/server/domain/comment/dto/ChildCommentResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/dto/ChildCommentResponse.java
@@ -1,0 +1,32 @@
+package com.shy_polarbear.server.domain.comment.dto;
+
+import com.shy_polarbear.server.domain.comment.model.Comment;
+import lombok.Builder;
+
+@Builder
+public record ChildCommentResponse(
+        Long commentId,
+        String content,
+        String createdDate,
+        boolean isDeleted,
+        String authorNickname,
+        String authorProfileImage,
+        boolean isAuthor,
+        boolean isLike,
+        long likeCount
+) {
+    public static ChildCommentResponse of(Comment comment, boolean isAuthor, boolean isLike) {
+        return ChildCommentResponse.builder()
+                .commentId(comment.getId())
+                .content(comment.getContent())
+                .createdDate(comment.getCreatedDate())
+                .isDeleted(comment.getVisibility())
+                .authorNickname(comment.getAuthor().getNickName())
+                .authorProfileImage(comment.getAuthor().getProfileImage())
+                .isAuthor(isAuthor)
+                .isLike(isLike)
+                .likeCount(comment.getCommentLikes().size())
+                .build();
+    }
+
+}

--- a/src/main/java/com/shy_polarbear/server/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/dto/CommentResponse.java
@@ -1,0 +1,39 @@
+package com.shy_polarbear.server.domain.comment.dto;
+
+import com.shy_polarbear.server.domain.comment.model.Comment;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record CommentResponse(
+        Long commentId,
+        String content,
+        String createdDate,
+        boolean isDeleted,
+        String authorNickname,
+        String authorProfileImage,
+        boolean isAuthor,
+        boolean isLike,
+        long likeCount,
+        List<ChildCommentResponse> childComments
+
+) {
+    public static CommentResponse of(Comment comment, boolean isAuthor, boolean isLike, List<Comment> childCommentList, Long userId) {
+        return CommentResponse.builder()
+                .commentId(comment.getId())
+                .content(comment.getContent())
+                .createdDate(comment.getCreatedDate())
+                .isDeleted(!comment.getVisibility())
+                .authorNickname(comment.getAuthor().getNickName())
+                .authorProfileImage(comment.getAuthor().getProfileImage())
+                .isAuthor(isAuthor)
+                .isLike(isLike)
+                .likeCount(comment.getCommentLikes().size())
+                .createdDate(comment.getCreatedDate())
+                .isDeleted(comment.getVisibility())
+                .childComments(childCommentList.stream().map(it -> ChildCommentResponse.of(it, it.isAuthor(userId), it.isLike(userId))).toList())
+                .build();
+    }
+}
+

--- a/src/main/java/com/shy_polarbear/server/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/dto/request/CommentCreateRequest.java
@@ -1,9 +1,11 @@
 package com.shy_polarbear.server.domain.comment.dto.request;
 
+import com.shy_polarbear.server.global.common.constants.BusinessLogicConstants;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 
 import javax.validation.constraints.NotNull;
 
@@ -13,6 +15,7 @@ import javax.validation.constraints.NotNull;
 @AllArgsConstructor
 public class CommentCreateRequest {
     @NotNull
+    @Length(max = BusinessLogicConstants.COMMENT_CONTENT_MAX_LENGTH)
     private String content;
 
     private Long parentId;   // nullable

--- a/src/main/java/com/shy_polarbear/server/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/dto/request/CommentCreateRequest.java
@@ -1,0 +1,18 @@
+package com.shy_polarbear.server.domain.comment.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentCreateRequest {
+    @NotNull
+    private String content;
+
+    private Long parentId;   // nullable
+}

--- a/src/main/java/com/shy_polarbear/server/domain/comment/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/dto/request/CommentUpdateRequest.java
@@ -1,9 +1,11 @@
 package com.shy_polarbear.server.domain.comment.dto.request;
 
+import com.shy_polarbear.server.global.common.constants.BusinessLogicConstants;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 
 import javax.validation.constraints.NotNull;
 
@@ -13,5 +15,6 @@ import javax.validation.constraints.NotNull;
 @AllArgsConstructor
 public class CommentUpdateRequest {
     @NotNull
+    @Length(max = BusinessLogicConstants.COMMENT_CONTENT_MAX_LENGTH)
     String content;
 }

--- a/src/main/java/com/shy_polarbear/server/domain/comment/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/dto/request/CommentUpdateRequest.java
@@ -11,9 +11,7 @@ import javax.validation.constraints.NotNull;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CommentCreateRequest {
+public class CommentUpdateRequest {
     @NotNull
-    private String content;
-
-    private Long parentId;   // nullable
+    String content;
 }

--- a/src/main/java/com/shy_polarbear/server/domain/comment/dto/response/ChildCommentResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/dto/response/ChildCommentResponse.java
@@ -1,4 +1,4 @@
-package com.shy_polarbear.server.domain.comment.dto;
+package com.shy_polarbear.server.domain.comment.dto.response;
 
 import com.shy_polarbear.server.domain.comment.model.Comment;
 import lombok.Builder;

--- a/src/main/java/com/shy_polarbear/server/domain/comment/dto/response/ChildCommentResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/dto/response/ChildCommentResponse.java
@@ -20,7 +20,7 @@ public record ChildCommentResponse(
                 .commentId(comment.getId())
                 .content(comment.getContent())
                 .createdDate(comment.getCreatedDate())
-                .isDeleted(comment.getVisibility())
+                .isDeleted(!comment.getVisibility())
                 .authorNickname(comment.getAuthor().getNickName())
                 .authorProfileImage(comment.getAuthor().getProfileImage())
                 .isAuthor(isAuthor)

--- a/src/main/java/com/shy_polarbear/server/domain/comment/dto/response/CommentCreateResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/dto/response/CommentCreateResponse.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 
 @Builder
 public record CommentCreateResponse(
-        Long commentId,
+        long commentId,
         Long parentId  // nullable
 ) {
     public static CommentCreateResponse ofChild(Comment comment) {

--- a/src/main/java/com/shy_polarbear/server/domain/comment/dto/response/CommentCreateResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/dto/response/CommentCreateResponse.java
@@ -1,0 +1,24 @@
+package com.shy_polarbear.server.domain.comment.dto.response;
+
+import com.shy_polarbear.server.domain.comment.model.Comment;
+import lombok.Builder;
+
+@Builder
+public record CommentCreateResponse(
+        Long commentId,
+        Long parentId  // nullable
+) {
+    public static CommentCreateResponse ofChild(Comment comment) {
+        return CommentCreateResponse.builder()
+                .parentId(comment.getParent().getId())
+                .commentId(comment.getId())
+                .build();
+    }
+
+    public static CommentCreateResponse ofParent(Comment comment) {
+        return CommentCreateResponse.builder()
+                .commentId(comment.getId())
+                .build();
+    }
+}
+

--- a/src/main/java/com/shy_polarbear/server/domain/comment/dto/response/CommentDeleteResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/dto/response/CommentDeleteResponse.java
@@ -1,0 +1,14 @@
+package com.shy_polarbear.server.domain.comment.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CommentDeleteResponse(
+        long commentId
+) {
+    public static CommentDeleteResponse of(long commentId) {
+        return CommentDeleteResponse.builder()
+                .commentId(commentId)
+                .build();
+    }
+}

--- a/src/main/java/com/shy_polarbear/server/domain/comment/dto/response/CommentLikeResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/dto/response/CommentLikeResponse.java
@@ -1,0 +1,14 @@
+package com.shy_polarbear.server.domain.comment.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CommentLikeResponse (
+        boolean isLiked
+){
+    public static CommentLikeResponse of(boolean isLiked) {
+        return CommentLikeResponse.builder()
+                .isLiked(isLiked)
+                .build();
+    }
+}

--- a/src/main/java/com/shy_polarbear/server/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/dto/response/CommentResponse.java
@@ -1,4 +1,4 @@
-package com.shy_polarbear.server.domain.comment.dto;
+package com.shy_polarbear.server.domain.comment.dto.response;
 
 import com.shy_polarbear.server.domain.comment.model.Comment;
 import lombok.Builder;

--- a/src/main/java/com/shy_polarbear/server/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/dto/response/CommentResponse.java
@@ -30,8 +30,6 @@ public record CommentResponse(
                 .isAuthor(isAuthor)
                 .isLike(isLike)
                 .likeCount(comment.getCommentLikes().size())
-                .createdDate(comment.getCreatedDate())
-                .isDeleted(comment.getVisibility())
                 .childComments(childCommentList.stream().map(it -> ChildCommentResponse.of(it, it.isAuthor(userId), it.isLike(userId))).toList())
                 .build();
     }

--- a/src/main/java/com/shy_polarbear/server/domain/comment/dto/response/CommentUpdateResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/dto/response/CommentUpdateResponse.java
@@ -1,0 +1,16 @@
+package com.shy_polarbear.server.domain.comment.dto.response;
+
+import com.shy_polarbear.server.domain.comment.model.Comment;
+import lombok.Builder;
+
+@Builder
+public record CommentUpdateResponse(
+        long commentId
+) {
+    public static CommentUpdateResponse of(Comment comment) {
+        return CommentUpdateResponse.builder()
+                .commentId(comment.getId())
+                .build();
+    }
+}
+

--- a/src/main/java/com/shy_polarbear/server/domain/comment/exception/CommentException.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/exception/CommentException.java
@@ -1,0 +1,10 @@
+package com.shy_polarbear.server.domain.comment.exception;
+
+import com.shy_polarbear.server.global.exception.CustomException;
+import com.shy_polarbear.server.global.exception.ExceptionStatus;
+
+public class CommentException extends CustomException {
+    public CommentException(ExceptionStatus exceptionStatus) {
+        super(exceptionStatus);
+    }
+}

--- a/src/main/java/com/shy_polarbear/server/domain/comment/model/Comment.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/model/Comment.java
@@ -85,8 +85,8 @@ public class Comment extends BaseEntity {
     }
 
 
-    public boolean isAuthor(User user) {
-        return this.author.getId().equals(user.getId());
+    public boolean isAuthor(Long userId) {
+        return this.author.getId().equals(userId);
     }
 
     public void addChildComment(Comment comment) {
@@ -110,9 +110,9 @@ public class Comment extends BaseEntity {
         this.commentLikes.add(commentLike);
     }
 
-    public boolean isLike(User user) {
+    public boolean isLike(Long userId) {
         return commentLikes.stream()
-                .anyMatch(commentLike -> commentLike.isAuthor(user));
+                .anyMatch(commentLike -> commentLike.isAuthor(userId));
     }
 
 }

--- a/src/main/java/com/shy_polarbear/server/domain/comment/model/Comment.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/model/Comment.java
@@ -76,8 +76,17 @@ public class Comment extends BaseEntity {
     }
 
 
-    public void addLike(CommentLike commentLike) {
-        this.commentLikes.add(commentLike);
+    public void update(String content) {
+        this.content = content;
+    }
+
+    public void softDelete() {  // 논리적 삭제(소프트 딜리트와 유사)
+        this.visibility = false;
+    }
+
+
+    public boolean isAuthor(User user) {
+        return this.author.getId().equals(user.getId());
     }
 
     public void addChildComment(Comment comment) {
@@ -89,28 +98,21 @@ public class Comment extends BaseEntity {
         this.parent = comment;
     }
 
-    public boolean isAuthor(User user) {
-        return this.author.getId().equals(user.getId());
+    public boolean isParent() {
+        return Objects.isNull(this.parent);
+    }
+
+    public boolean isChild() {
+        return Objects.nonNull(this.parent);
+    }
+
+    public void addLike(CommentLike commentLike) {
+        this.commentLikes.add(commentLike);
     }
 
     public boolean isLike(User user) {
         return commentLikes.stream()
                 .anyMatch(commentLike -> commentLike.isAuthor(user));
-    }
-
-    public boolean isParent() {
-        return Objects.isNull(this.parent);
-    }
-    public boolean isChild() {
-        return Objects.nonNull(this.parent);
-    }
-
-    public void update(String content) {
-        this.content = content;
-    }
-
-    public void softDelete() {  // 논리적 삭제(소프트 딜리트와 유사)
-        this.visibility = false;
     }
 
 }

--- a/src/main/java/com/shy_polarbear/server/domain/comment/model/Comment.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/model/Comment.java
@@ -46,7 +46,7 @@ public class Comment extends BaseEntity {
             cascade = {CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
     private final List<Comment> childComments = new ArrayList<>();
 
-    @OneToMany(mappedBy = "comment")
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL)
     private final List<CommentLike> commentLikes = new ArrayList<>();
 
 

--- a/src/main/java/com/shy_polarbear/server/domain/comment/model/Comment.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/model/Comment.java
@@ -115,4 +115,8 @@ public class Comment extends BaseEntity {
                 .anyMatch(commentLike -> commentLike.isAuthor(userId));
     }
 
+    // test
+    public void setIdForTest(Long mockId) {
+        this.id = mockId;
+    }
 }

--- a/src/main/java/com/shy_polarbear/server/domain/comment/model/CommentLike.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/model/CommentLike.java
@@ -41,8 +41,8 @@ public class CommentLike extends BaseEntity {
         return commentLike;
     }
 
-    public boolean isAuthor(User user) {
-        return this.user.getId().equals(user.getId());
+    public boolean isAuthor(Long userId) {
+        return this.user.getId().equals(userId);
 
     }
 }

--- a/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentLikeRepository.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentLikeRepository.java
@@ -1,0 +1,14 @@
+package com.shy_polarbear.server.domain.comment.repository;
+
+import com.shy_polarbear.server.domain.comment.model.Comment;
+import com.shy_polarbear.server.domain.comment.model.CommentLike;
+import com.shy_polarbear.server.domain.user.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+    Boolean existsByUserIdAndCommentId(Long userId, Long commentId);
+
+    Optional<CommentLike> findByUserAndComment(User user, Comment comment);
+}

--- a/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryCustom.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryCustom.java
@@ -2,10 +2,14 @@ package com.shy_polarbear.server.domain.comment.repository;
 
 import com.shy_polarbear.server.domain.comment.model.Comment;
 import com.shy_polarbear.server.domain.feed.model.Feed;
+import org.springframework.data.domain.Slice;
 
 import java.util.Optional;
 
 public interface CommentRepositoryCustom {
 
     Optional<Comment> findBestComment(Feed feed);
+
+    Slice<Comment> findAllParentComment(long currentUserId, long feedId, Long cursorId, int limit);
+
 }

--- a/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryImpl.java
@@ -5,17 +5,24 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.shy_polarbear.server.domain.comment.model.Comment;
 import com.shy_polarbear.server.domain.feed.model.Feed;
+import com.shy_polarbear.server.global.common.util.CustomSliceExecutionUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
-import static com.shy_polarbear.server.domain.comment.model.QComment.*;
+import static com.shy_polarbear.server.domain.comment.model.QComment.comment;
+import static com.shy_polarbear.server.domain.comment.model.QCommentLike.commentLike;
+import static com.shy_polarbear.server.domain.feed.model.QFeed.feed;
+import static com.shy_polarbear.server.domain.user.model.QUser.user;
 
 @Repository
 @RequiredArgsConstructor
-public class CommentRepositoryImpl implements CommentRepositoryCustom{
+public class CommentRepositoryImpl implements CommentRepositoryCustom {
     private final JPAQueryFactory queryFactory;
+
     @Override
     public Optional<Comment> findBestComment(Feed feed) {
         JPAQuery<Comment> query = queryFactory
@@ -28,7 +35,36 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom{
         return Optional.ofNullable(query.fetchFirst());
     }
 
+    // TODO: 현재는 child comment, comment_like 에 대해 default batch size (IN 절)로 쿼리 날리는 상태. VO 만들고, 부모와 자식 FETCH JOIN 해보자.
+    @Override
+    public Slice<Comment> findAllParentComment(long currentUserId, long feedId, Long cursorId, int limit) {
+        JPAQuery<Comment> query = queryFactory
+                .selectFrom(comment)
+                .leftJoin(comment.author, user).fetchJoin()
+                .leftJoin(comment.feed, feed).fetchJoin()
+                .join(comment.commentLikes, commentLike).fetchJoin()
+                .where(eqFeedId(feedId).and(gtCursorId(cursorId))
+                        .and(comment.parent.isNull()))
+                .orderBy(comment.id.asc())  // 오래된 순
+                .limit(CustomSliceExecutionUtils.buildSliceLimit(limit));
+
+        return CustomSliceExecutionUtils.getSlice(query.fetch(), limit);
+    }
+
     private static BooleanExpression checkFeed(Feed feed) {
         return comment.feed.id.eq(feed.getId());
+    }
+
+    private static BooleanExpression inParentIds(List<Long> parentIdList) {
+        return comment.parent.id.in(parentIdList);
+    }
+
+    private static BooleanExpression eqFeedId(long feedId) {
+        return comment.feed.id.eq(feedId);
+    }
+
+    private static BooleanExpression gtCursorId(Long cursorId) {
+        if (cursorId == null || cursorId == 0) return null;
+        else return comment.id.gt(cursorId);
     }
 }

--- a/src/main/java/com/shy_polarbear/server/domain/comment/service/CommentService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/service/CommentService.java
@@ -1,4 +1,43 @@
 package com.shy_polarbear.server.domain.comment.service;
 
+import com.shy_polarbear.server.domain.comment.dto.CommentResponse;
+import com.shy_polarbear.server.domain.comment.model.Comment;
+import com.shy_polarbear.server.domain.comment.repository.CommentRepository;
+import com.shy_polarbear.server.domain.user.service.UserService;
+import com.shy_polarbear.server.global.common.dto.NoCountPageResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class CommentService {
+    private final UserService userService;
+    private final CommentRepository commentRepository;
+
+    // 댓글 리스트 조회 (무한 스크롤)
+    public NoCountPageResponse<CommentResponse> getComments(Long currentUserId, Long feedId, Long cursorId, int limit) {
+        Slice<Comment> parentComments = commentRepository.findAllParentComment(currentUserId, feedId, cursorId, limit);
+        Slice<CommentResponse> result = parentComments.map(
+                it -> CommentResponse.of(it, it.isAuthor(currentUserId), it.isLike(currentUserId), it.getChildComments(), currentUserId)
+        );
+
+        return NoCountPageResponse.of(result);
+    }
+
+    // 댓글 생성
+
+
+    // 댓글 수정
+
+
+    // 댓글 좋아요 혹은 좋아요 취소
+
+
+    // 댓글 삭제
 }

--- a/src/main/java/com/shy_polarbear/server/domain/comment/service/CommentService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/service/CommentService.java
@@ -1,15 +1,25 @@
 package com.shy_polarbear.server.domain.comment.service;
 
-import com.shy_polarbear.server.domain.comment.dto.CommentResponse;
+import com.shy_polarbear.server.domain.comment.dto.request.CommentCreateRequest;
+import com.shy_polarbear.server.domain.comment.dto.response.CommentCreateResponse;
+import com.shy_polarbear.server.domain.comment.dto.response.CommentResponse;
+import com.shy_polarbear.server.domain.comment.exception.CommentException;
 import com.shy_polarbear.server.domain.comment.model.Comment;
 import com.shy_polarbear.server.domain.comment.repository.CommentRepository;
+import com.shy_polarbear.server.domain.feed.model.Feed;
+import com.shy_polarbear.server.domain.feed.repository.FeedRepository;
+import com.shy_polarbear.server.domain.feed.service.FeedService;
+import com.shy_polarbear.server.domain.user.model.User;
 import com.shy_polarbear.server.domain.user.service.UserService;
 import com.shy_polarbear.server.global.common.dto.NoCountPageResponse;
+import com.shy_polarbear.server.global.exception.ExceptionStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
 
 
 @Slf4j
@@ -18,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CommentService {
     private final UserService userService;
+    private final FeedService feedService;
     private final CommentRepository commentRepository;
 
     // 댓글 리스트 조회 (무한 스크롤)
@@ -31,7 +42,21 @@ public class CommentService {
     }
 
     // 댓글 생성
+    @Transactional
+    public CommentCreateResponse createComment(Long currentUserId, Long feedId, CommentCreateRequest request) {
+        User user = userService.getUser(currentUserId);
+        Feed feed = feedService.findFeedById(feedId);
 
+        Long parentId = request.getParentId();
+        if (Objects.isNull(parentId)) {    // 부모 댓글
+            Comment comment = commentRepository.save(Comment.createComment(user, request.getContent(), feed));
+            return CommentCreateResponse.ofParent(comment);
+        } else {    // 자식 댓글
+            Comment parent = commentRepository.findById(parentId).orElseThrow(() -> new CommentException(ExceptionStatus.NOT_FOUND_COMMENT));
+            Comment comment = commentRepository.save(Comment.createChildComment(user, request.getContent(), feed, parent));
+            return CommentCreateResponse.ofChild(comment);
+        }
+    }
 
     // 댓글 수정
 

--- a/src/main/java/com/shy_polarbear/server/domain/comment/service/CommentService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/service/CommentService.java
@@ -1,13 +1,14 @@
 package com.shy_polarbear.server.domain.comment.service;
 
 import com.shy_polarbear.server.domain.comment.dto.request.CommentCreateRequest;
+import com.shy_polarbear.server.domain.comment.dto.request.CommentUpdateRequest;
 import com.shy_polarbear.server.domain.comment.dto.response.CommentCreateResponse;
 import com.shy_polarbear.server.domain.comment.dto.response.CommentResponse;
+import com.shy_polarbear.server.domain.comment.dto.response.CommentUpdateResponse;
 import com.shy_polarbear.server.domain.comment.exception.CommentException;
 import com.shy_polarbear.server.domain.comment.model.Comment;
 import com.shy_polarbear.server.domain.comment.repository.CommentRepository;
 import com.shy_polarbear.server.domain.feed.model.Feed;
-import com.shy_polarbear.server.domain.feed.repository.FeedRepository;
 import com.shy_polarbear.server.domain.feed.service.FeedService;
 import com.shy_polarbear.server.domain.user.model.User;
 import com.shy_polarbear.server.domain.user.service.UserService;
@@ -59,10 +60,26 @@ public class CommentService {
     }
 
     // 댓글 수정
+    @Transactional
+    public CommentUpdateResponse updateComment(Long currentUserId, Long commentId, CommentUpdateRequest request) {
+        User user = userService.getUser(currentUserId);
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentException(ExceptionStatus.NOT_FOUND_COMMENT));
+        checkIsAuthor(user, comment);
 
+        comment.update(request.getContent());
+
+        return CommentUpdateResponse.of(comment);
+    }
 
     // 댓글 좋아요 혹은 좋아요 취소
 
 
     // 댓글 삭제
+
+
+    private static void checkIsAuthor(User user, Comment comment) {
+        if (!comment.isAuthor(user.getId()))
+            throw new CommentException(ExceptionStatus.NOT_MY_COMMENT);
+    }
 }

--- a/src/main/java/com/shy_polarbear/server/domain/feed/dto/response/FeedCardResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/dto/response/FeedCardResponse.java
@@ -55,8 +55,8 @@ public class FeedCardResponse {
                     .authorProfileImage((commentAuthor.getProfileImage() == null) ? "" : commentAuthor.getProfileImage())
                     .content(comment.getContent())
                     .likeCount(comment.getCommentLikes().size())
-                    .isAuthor(comment.isAuthor(user))
-                    .isLike(comment.isLike(user))
+                    .isAuthor(comment.isAuthor(user.getId()))
+                    .isLike(comment.isLike(user.getId()))
                     .createdDate(comment.getCreatedDate())
                     .build();
         } else {

--- a/src/main/java/com/shy_polarbear/server/domain/feed/service/FeedService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/service/FeedService.java
@@ -65,7 +65,7 @@ public class FeedService {
         return new UpdateFeedResponse(feedId);
     }
 
-    private Feed findFeedById(Long feedId) {
+    public Feed findFeedById(Long feedId) {
         Feed findFeed = feedRepository.findById(feedId)
                 .orElseThrow(() -> new FeedException(ExceptionStatus.NOT_FOUND_FEED));
         return findFeed;

--- a/src/main/java/com/shy_polarbear/server/domain/user/model/User.java
+++ b/src/main/java/com/shy_polarbear/server/domain/user/model/User.java
@@ -117,4 +117,9 @@ public class User extends BaseEntity {
     public boolean isSameNickName(String nickName) {
         return Objects.equals(this.nickName, nickName);
     }
+
+    // test
+    public void setIdForTest(Long mockId) {
+        this.id = mockId;
+    }
 }

--- a/src/main/java/com/shy_polarbear/server/global/common/constants/BusinessLogicConstants.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/constants/BusinessLogicConstants.java
@@ -14,4 +14,9 @@ public abstract class BusinessLogicConstants {
     public static final String FEED_LIMIT_PARAM_DEFAULT_VALUE = "10";
     public static final int RECENT_BEST_FEED_DAY_LIMIT = 7;
 
+    /**
+     * 댓글, 대댓글
+     **/
+    public static final int COMMENT_CONTENT_MAX_LENGTH = 300;
+
 }

--- a/src/main/java/com/shy_polarbear/server/global/common/constants/BusinessLogicConstants.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/constants/BusinessLogicConstants.java
@@ -18,5 +18,6 @@ public abstract class BusinessLogicConstants {
      * 댓글, 대댓글
      **/
     public static final int COMMENT_CONTENT_MAX_LENGTH = 300;
+    public static final String COMMENT_LIMIT_PARAM_DEFAULT_VALUE = "10";
 
 }

--- a/src/main/java/com/shy_polarbear/server/global/common/dummy/CommentInitializer.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/dummy/CommentInitializer.java
@@ -1,0 +1,69 @@
+package com.shy_polarbear.server.global.common.dummy;
+
+import com.shy_polarbear.server.domain.comment.model.Comment;
+import com.shy_polarbear.server.domain.comment.model.CommentLike;
+import com.shy_polarbear.server.domain.comment.repository.CommentRepository;
+import com.shy_polarbear.server.domain.feed.model.Feed;
+import com.shy_polarbear.server.domain.feed.repository.FeedRepository;
+import com.shy_polarbear.server.domain.user.exception.UserException;
+import com.shy_polarbear.server.domain.user.model.User;
+import com.shy_polarbear.server.domain.user.repository.UserRepository;
+import com.shy_polarbear.server.global.common.constants.ProfileConstants;
+import com.shy_polarbear.server.global.exception.ExceptionStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.transaction.Transactional;
+
+import java.util.List;
+
+import static com.shy_polarbear.server.global.common.dummy.LoginUserInitializer.LOGIN_USER_PROVIDER_ID;
+
+@Component("CommentInitializer")
+@DependsOn({"FeedInitializer"})
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+@Profile({ProfileConstants.LOCAL, ProfileConstants.DEV})
+public class CommentInitializer {
+    private final FeedRepository feedRepository;
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+
+    @PostConstruct
+    public void init() {
+        if (commentRepository.count() == 0) {
+            createDummyComment();
+            log.info("[CommentInitializer] 댓글 생성 완료");
+        } else {
+            log.info("[CommentInitializer] 댓글 이미 존재");
+        }
+    }
+
+    private void createDummyComment() {
+        User author = userRepository.findByProviderId(LOGIN_USER_PROVIDER_ID)
+                .orElseThrow(() -> new UserException(ExceptionStatus.NOT_FOUND_USER));
+        List<User> userList = userRepository.findAll();
+        List<Feed> feedList = feedRepository.findAll();
+
+        for (Feed feed : feedList) {
+            for (int i = 0; i < 25; i++) {
+                Comment parent = Comment.createComment(author, "부모 댓글" + i, feed);
+                for (User user : userList) {
+                    CommentLike.createCommentLike(parent, user);    // 댓글 좋아요
+                }
+                commentRepository.save(parent);
+
+                for (int j = 0; j < 5; j++) {
+                    commentRepository.save(Comment.createChildComment(author, "자식 댓글" + i, feed, parent));
+                }
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/com/shy_polarbear/server/global/common/dummy/FeedInitializer.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/dummy/FeedInitializer.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import static com.shy_polarbear.server.global.common.dummy.LoginUserInitializer.LOGIN_USER_PROVIDER_ID;
 
-@Component
+@Component("FeedInitializer")
 @DependsOn("LoginUserInitializer")
 @RequiredArgsConstructor
 @Slf4j

--- a/src/main/java/com/shy_polarbear/server/global/common/dummy/LoginUserInitializer.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/dummy/LoginUserInitializer.java
@@ -1,9 +1,9 @@
 package com.shy_polarbear.server.global.common.dummy;
 
+import com.shy_polarbear.server.domain.user.model.ProviderType;
 import com.shy_polarbear.server.domain.user.model.User;
 import com.shy_polarbear.server.domain.user.model.UserRole;
 import com.shy_polarbear.server.domain.user.repository.UserRepository;
-import com.shy_polarbear.server.domain.user.model.ProviderType;
 import com.shy_polarbear.server.global.auth.jwt.JwtDto;
 import com.shy_polarbear.server.global.auth.jwt.JwtProvider;
 import com.shy_polarbear.server.global.common.constants.ProfileConstants;
@@ -24,12 +24,12 @@ import java.util.Optional;
 @Profile({ProfileConstants.LOCAL, ProfileConstants.DEV})
 public class LoginUserInitializer {
     private User user;
-    private String nickName = "노을";
-    private String email = "chi6465618@naver.com";
-    private String profileImage = "";
-    private String phoneNumber = "01093926465";
-    private UserRole userRole = UserRole.ROLE_USR;
-    private ProviderType provider = ProviderType.KAKAO;
+    private final String nickName = "노을";
+    private final String email = "chi6465618@naver.com";
+    private final String profileImage = "";
+    private final String phoneNumber = "01093926465";
+    private final UserRole userRole = UserRole.ROLE_USR;
+    private final ProviderType provider = ProviderType.KAKAO;
     static String LOGIN_USER_PROVIDER_ID = "0000";
 
     private final PasswordEncoder passwordEncoder;
@@ -50,6 +50,19 @@ public class LoginUserInitializer {
         } else {
             user = User.createUser(nickName, email, profileImage, phoneNumber, userRole, LOGIN_USER_PROVIDER_ID, provider, passwordEncoder);
             userRepository.save(user);
+
+            for (int i = 0; i < 10; i++) {
+                userRepository.save(User.createUser(
+                        "유저" + i,
+                        email + i,
+                        profileImage,
+                        phoneNumber + i,
+                        userRole,
+                        LOGIN_USER_PROVIDER_ID + i,
+                        provider,
+                        passwordEncoder
+                ));
+            }
         }
         JwtDto issue = jwtProvider.issue(user);
         log.info("더미 유저 access token : {}", issue.getAccessToken());

--- a/src/main/java/com/shy_polarbear/server/global/exception/ExceptionStatus.java
+++ b/src/main/java/com/shy_polarbear/server/global/exception/ExceptionStatus.java
@@ -33,6 +33,11 @@ public enum ExceptionStatus {
     NOT_FOUND_FEED(404, 2001, "존재하지 않는 피드입니다."),
     NOT_MY_FEED(400, 2002, "본인의 피드가 아닙니다."),
 
+    //댓글
+    NOT_FOUND_COMMENT(404, 2100, "존재하지 않는 댓글입니다."),
+    NOT_MY_COMMENT(404, 2104, "본인의 댓글이 아닙니다."),
+
+
     // 퀴즈
     ALREADY_SOLVED_DAILY_QUIZ(400, 3000, "이미 오늘 데일리 퀴즈를 풀었습니다."),
     NOT_FOUND_QUIZ(404, 3001, "존재하지 않는 퀴즈입니다."),

--- a/src/test/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryTest.java
@@ -125,11 +125,11 @@ public class CommentRepositoryTest {
 
         em.flush(); // DB에 영속성 반영 및 1차 캐시 삭제
         em.clear();
-        Optional<Comment> foundComment = commentRepository.findById(comment.getId());
+        Optional<Comment> commentAble = commentRepository.findById(comment.getId());
 
         // then
-        assertThatNoException().isThrownBy(foundComment::get);
-        assertThat(foundComment.isPresent()).isTrue();
-        assertThat(foundComment.get().getVisibility()).isFalse();
+        assertThatNoException().isThrownBy(commentAble::get);
+        assertThat(commentAble.isPresent()).isTrue();
+        assertThat(commentAble.get().getVisibility()).isFalse();
     }
 }

--- a/src/test/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryTest.java
@@ -124,7 +124,7 @@ public class CommentRepositoryTest {
     }
 
     @Test
-    @DisplayName("SOFT DELETE 댓글 성공 : 엔티티가 존재 && presence == false")
+    @DisplayName("SOFT DELETE 댓글 성공 : 엔티티가 존재 && visibility == false")
     public void softDeleteComment() {
         // given
         Comment comment = commentRepository.save(Comment.createComment(dummyUser, "댓글", dummyFeed));
@@ -137,13 +137,12 @@ public class CommentRepositoryTest {
         Optional<Comment> commentAble = commentRepository.findById(comment.getId());
 
         // then
-        assertThatNoException().isThrownBy(commentAble::get);
         assertThat(commentAble.isPresent()).isTrue();
         assertThat(commentAble.get().getVisibility()).isFalse();
     }
 
     @Test
-    @DisplayName("findAllParentComment 성공")
+    @DisplayName("SELECT findAllParentComment 성공")
     public void findAllParentCommentSuccess() {
         // given
         int limit = 10;

--- a/src/test/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryTest.java
@@ -1,0 +1,135 @@
+package com.shy_polarbear.server.domain.comment.repository;
+
+import com.shy_polarbear.server.config.TestJpaConfig;
+import com.shy_polarbear.server.domain.comment.model.Comment;
+import com.shy_polarbear.server.domain.feed.model.Feed;
+import com.shy_polarbear.server.domain.feed.model.FeedImage;
+import com.shy_polarbear.server.domain.feed.repository.FeedRepository;
+import com.shy_polarbear.server.domain.user.model.User;
+import com.shy_polarbear.server.domain.user.repository.UserRepository;
+import com.shy_polarbear.server.domain.user.template.UserTemplate;
+import org.h2.jdbc.JdbcSQLDataException;
+import org.hibernate.exception.DataException;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+@TestMethodOrder(MethodOrderer.DisplayName.class)
+@DataJpaTest
+@Import(TestJpaConfig.class)
+public class CommentRepositoryTest {
+    private User dummyUser;
+    private Feed dummyFeed;
+
+    private final int DUMMY_FEED_SIZE = 10;
+    private final int DUMMY_COMMENT_PER_FEED_SIZE = 20;
+
+    @Autowired
+    CommentRepository commentRepository;
+
+    @Autowired
+    FeedRepository feedRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @BeforeEach
+    void setUp() {
+        this.dummyUser = userRepository.save(UserTemplate.createDummyUser());
+
+        for (int i = 0; i < DUMMY_FEED_SIZE; i++) {
+            Feed saved = feedRepository.save(Feed.createFeed(
+                    "title" + i,
+                    "content" + i,
+                    FeedImage.createFeedImages(List.of("imageurl" + i)),
+                    dummyUser
+            ));
+            if (i == 0) dummyFeed = saved;
+        }
+    }
+
+    @Test
+    @DisplayName("INSERT 부모 댓글 성공")
+    public void parentCommentInsertSuccess() {
+        // given
+        Comment comment = Comment.createComment(dummyUser, "댓글", dummyFeed);
+
+        // when & then
+        assertThat(comment.isParent()).isTrue();
+        assertThatNoException().isThrownBy(() -> commentRepository.save(comment));
+        assertThat(commentRepository.save(comment).getVisibility()).isEqualTo(true);  // 디폴트 값 확인
+    }
+
+    @Test
+    @DisplayName("INSERT 자식 댓글 성공")
+    public void childCommentInsertSuccess() {
+        // given
+        Comment parent = commentRepository.save(Comment.createComment(dummyUser, "부모 댓글", dummyFeed));
+        Comment comment = Comment.createChildComment(dummyUser, "자식 댓글", dummyFeed, parent);
+
+        // when & then
+        assertThat(comment.isChild()).isTrue();
+        assertThatNoException().isThrownBy(() -> commentRepository.save(comment));
+        assertThat(commentRepository.save(comment).getVisibility()).isEqualTo(true);  // 디폴트 값 확인
+    }
+
+    @Test
+    @DisplayName("INSERT 댓글 실패 : NOT NULL 제약 위반")
+    public void commentInsertNullFieldFail() {
+        // given
+        Comment authorNullcomment = Comment.createComment(null, "댓글", dummyFeed);
+        Comment contentNullcomment = Comment.createComment(dummyUser, null, dummyFeed);
+        Comment feedNullcomment = Comment.createComment(dummyUser, "댓글", null);
+
+        // when & then
+        assertThatThrownBy(() -> commentRepository.save(authorNullcomment))
+                .isInstanceOf(DataIntegrityViolationException.class);
+        assertThatThrownBy(() -> commentRepository.save(contentNullcomment))
+                .isInstanceOf(DataIntegrityViolationException.class);
+        assertThatThrownBy(() -> commentRepository.save(feedNullcomment))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("INSERT 댓글 실패 : content 글자수 제약 위반")
+    public void commentInsertLengthFieldFail() {
+        // given
+        final String hugeContent = String.format("%330s", "댓글");
+        Comment hugeContentComment = Comment.createComment(dummyUser, hugeContent, dummyFeed);
+
+        // when & then
+        assertThatThrownBy(() -> commentRepository.save(hugeContentComment))
+                .hasCauseInstanceOf(DataException.class)
+                .hasStackTraceContaining("Value too long");
+    }
+
+    @Test
+    @DisplayName("SOFT DELETE 댓글 성공 : 엔티티가 존재 && presence == false")
+    public void softDeleteComment() {
+        // given
+        Comment comment = commentRepository.save(Comment.createComment(dummyUser, "댓글", dummyFeed));
+
+        // when
+        comment.softDelete();
+
+        em.flush(); // DB에 영속성 반영 및 1차 캐시 삭제
+        em.clear();
+        Optional<Comment> foundComment = commentRepository.findById(comment.getId());
+
+        // then
+        assertThatNoException().isThrownBy(foundComment::get);
+        assertThat(foundComment.isPresent()).isTrue();
+        assertThat(foundComment.get().getVisibility()).isFalse();
+    }
+}

--- a/src/test/java/com/shy_polarbear/server/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/shy_polarbear/server/domain/comment/service/CommentServiceTest.java
@@ -1,0 +1,137 @@
+package com.shy_polarbear.server.domain.comment.service;
+
+import com.shy_polarbear.server.domain.comment.dto.request.CommentCreateRequest;
+import com.shy_polarbear.server.domain.comment.dto.request.CommentUpdateRequest;
+import com.shy_polarbear.server.domain.comment.dto.response.CommentCreateResponse;
+import com.shy_polarbear.server.domain.comment.dto.response.CommentUpdateResponse;
+import com.shy_polarbear.server.domain.comment.exception.CommentException;
+import com.shy_polarbear.server.domain.comment.model.Comment;
+import com.shy_polarbear.server.domain.comment.repository.CommentRepository;
+import com.shy_polarbear.server.domain.comment.template.CommentTemplate;
+import com.shy_polarbear.server.domain.feed.model.Feed;
+import com.shy_polarbear.server.domain.feed.service.FeedService;
+import com.shy_polarbear.server.domain.feed.template.FeedTemplate;
+import com.shy_polarbear.server.domain.user.model.User;
+import com.shy_polarbear.server.domain.user.service.UserService;
+import com.shy_polarbear.server.domain.user.template.UserTemplate;
+import com.shy_polarbear.server.global.exception.ExceptionStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+@TestMethodOrder(MethodOrderer.DisplayName.class)
+@ExtendWith(MockitoExtension.class)
+public class CommentServiceTest {
+    @InjectMocks
+    CommentService commentService;
+
+    @Mock
+    UserService userService;
+    @Mock
+    FeedService feedService;
+    @Mock
+    CommentRepository commentRepository;
+
+    private final User dummyUser = UserTemplate.createDummyUser();
+    private final User dummyOtherUserA = UserTemplate.createDummyOtherUserA();
+    private final Feed dummyFeed = FeedTemplate.createDummyFeed();
+    private final Comment dummyParentComment = CommentTemplate.createDummyParentComment();
+    private final Comment dummyChildComment = CommentTemplate.createDummyChildComment(dummyParentComment);
+
+
+    @Test
+    @DisplayName("createComment 성공")
+    public void createCommentSuccess() {
+        // given
+        given(userService.getUser(anyLong())).willReturn(dummyUser);
+        given(feedService.findFeedById(anyLong())).willReturn(dummyFeed);
+        given(commentRepository.save(any())).willReturn(dummyParentComment);
+
+        // when
+        CommentCreateRequest request = CommentCreateRequest.builder().content("부모 댓글").build();
+        CommentCreateResponse response = commentService.createComment(UserTemplate.ID, 1L, request);
+
+        // then
+        assertThat(response.parentId()).isNull();
+        assertThat(response.commentId()).isEqualTo(CommentTemplate.PARENT_ID);
+    }
+
+    @Test
+    @DisplayName("createComment 실패: 존재하지 않는 부모 댓글")
+    public void createCommentNotFoundFeedFail() {
+        // given
+        given(userService.getUser(anyLong())).willReturn(dummyUser);
+        given(feedService.findFeedById(anyLong())).willReturn(dummyFeed);
+        given(commentRepository.findById(anyLong())).willReturn(Optional.empty());  // 예외 발생
+
+        // when & then
+        CommentCreateRequest request = CommentCreateRequest.builder().content("자식 댓글").parentId(anyLong()).build();
+        assertThatThrownBy(() -> commentService.createComment(UserTemplate.ID, 1L, request))
+                .isInstanceOf(CommentException.class)
+                .hasMessage(ExceptionStatus.NOT_FOUND_COMMENT.getMessage());
+    }
+
+    // 업데이트 성공
+    // 업데이트 실패: 존재하지 않는 댓글, 작성자가 아닌 경우
+    @Test
+    @DisplayName("updateComment 성공")
+    public void updateCommentSuccess() {
+        // given
+        given(userService.getUser(anyLong())).willReturn(dummyUser);
+        given(commentRepository.findById(anyLong())).willReturn(Optional.of(dummyParentComment));
+
+        // when
+        CommentUpdateRequest request = CommentUpdateRequest.builder().content("수정된 댓글").build();
+        CommentUpdateResponse response = commentService.updateComment(UserTemplate.ID, dummyParentComment.getId(), request);
+
+        // then
+        assertThat(response.commentId()).isEqualTo(dummyParentComment.getId());
+    }
+
+    @Test
+    @DisplayName("updateComment 실패: 존재하지 않는 댓글")
+    public void updateCommentNotFoundFail() {
+        // given
+        given(userService.getUser(anyLong())).willReturn(dummyUser);
+        given(commentRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // when & then
+        CommentUpdateRequest request = CommentUpdateRequest.builder().content("수정된 내용").build();
+        assertThatThrownBy(() -> commentService.updateComment(UserTemplate.ID, dummyParentComment.getId(), request))
+                .isInstanceOf(CommentException.class)
+                .hasMessage(ExceptionStatus.NOT_FOUND_COMMENT.getMessage());
+    }
+
+    @Test
+    @DisplayName("updateComment 실패: 작성자와 유저가 일치하지 않음")
+    public void updateCommentNotAuthorFail() {
+        // given
+        given(userService.getUser(anyLong())).willReturn(dummyOtherUserA);  // 예외 발생: dummyParentComment.User 와 다른 유저
+        given(commentRepository.findById(anyLong())).willReturn(Optional.of(dummyParentComment));
+
+        // when & then
+        CommentUpdateRequest request = CommentUpdateRequest.builder().content("수정된 내용").build();
+        assertThatThrownBy(() -> commentService.updateComment(UserTemplate.ID, dummyParentComment.getId(), request))
+                .isInstanceOf(CommentException.class)
+                .hasMessage(ExceptionStatus.NOT_MY_COMMENT.getMessage());
+    }
+
+    // 삭제 성공: 소프트 딜리트
+    // 삭제 실패: 존재하지 않는 댓글, 작성자가 아닌 경우
+
+    // 좋아요 성공: 좋아요, 좋아요 취소
+    // 좋아요 실패: 존재하지 않는 댓글
+}

--- a/src/test/java/com/shy_polarbear/server/domain/comment/template/CommentTemplate.java
+++ b/src/test/java/com/shy_polarbear/server/domain/comment/template/CommentTemplate.java
@@ -9,6 +9,9 @@ public class CommentTemplate {
     public static final String PARENT_CONTENT = "부모 댓글";
     public static final Long CHILD_ID = 200L;
     public static final String CHILD_CONTENT = "자식 댓글";
+    public static final Long DELETED_ID = 400L;
+    public static final String DELETED_CONTENT = "삭제된 댓글";
+
     public static Comment createDummyParentComment() {
         Comment comment = Comment.createComment(UserTemplate.createDummyUser(), PARENT_CONTENT, FeedTemplate.createDummyFeed());
         comment.setIdForTest(PARENT_ID);
@@ -18,6 +21,13 @@ public class CommentTemplate {
     public static Comment createDummyChildComment(Comment parent) {
         Comment comment = Comment.createChildComment(UserTemplate.createDummyUser(), CHILD_CONTENT, FeedTemplate.createDummyFeed(), parent);
         comment.setIdForTest(CHILD_ID);
+        return comment;
+    }
+
+    public static Comment createDummySoftDeletedComment() {
+        Comment comment = Comment.createComment(UserTemplate.createDummyUser(), DELETED_CONTENT, FeedTemplate.createDummyFeed());
+        comment.setIdForTest(DELETED_ID);
+        comment.softDelete();
         return comment;
     }
 }

--- a/src/test/java/com/shy_polarbear/server/domain/comment/template/CommentTemplate.java
+++ b/src/test/java/com/shy_polarbear/server/domain/comment/template/CommentTemplate.java
@@ -1,0 +1,23 @@
+package com.shy_polarbear.server.domain.comment.template;
+
+import com.shy_polarbear.server.domain.comment.model.Comment;
+import com.shy_polarbear.server.domain.feed.template.FeedTemplate;
+import com.shy_polarbear.server.domain.user.template.UserTemplate;
+
+public class CommentTemplate {
+    public static final Long PARENT_ID = 100L;
+    public static final String PARENT_CONTENT = "부모 댓글";
+    public static final Long CHILD_ID = 200L;
+    public static final String CHILD_CONTENT = "자식 댓글";
+    public static Comment createDummyParentComment() {
+        Comment comment = Comment.createComment(UserTemplate.createDummyUser(), PARENT_CONTENT, FeedTemplate.createDummyFeed());
+        comment.setIdForTest(PARENT_ID);
+        return comment;
+    }
+
+    public static Comment createDummyChildComment(Comment parent) {
+        Comment comment = Comment.createChildComment(UserTemplate.createDummyUser(), CHILD_CONTENT, FeedTemplate.createDummyFeed(), parent);
+        comment.setIdForTest(CHILD_ID);
+        return comment;
+    }
+}

--- a/src/test/java/com/shy_polarbear/server/domain/feed/template/FeedTemplate.java
+++ b/src/test/java/com/shy_polarbear/server/domain/feed/template/FeedTemplate.java
@@ -10,7 +10,7 @@ import java.util.List;
 public class FeedTemplate {
     public static Feed createDummyFeed() {
         User dummyUser = UserTemplate.createDummyUser();
-        List<String> imageUrls = List.of("image.com");
+        List<String> imageUrls = List.of("https://example.com/image.jpg");
         return Feed.createFeed("피드 제목", "피드 내용", FeedImage.createFeedImages(imageUrls), dummyUser);
     }
 }

--- a/src/test/java/com/shy_polarbear/server/domain/feed/template/FeedTemplate.java
+++ b/src/test/java/com/shy_polarbear/server/domain/feed/template/FeedTemplate.java
@@ -1,0 +1,16 @@
+package com.shy_polarbear.server.domain.feed.template;
+
+import com.shy_polarbear.server.domain.feed.model.Feed;
+import com.shy_polarbear.server.domain.feed.model.FeedImage;
+import com.shy_polarbear.server.domain.user.model.User;
+import com.shy_polarbear.server.domain.user.template.UserTemplate;
+
+import java.util.List;
+
+public class FeedTemplate {
+    public static Feed createDummyFeed() {
+        User dummyUser = UserTemplate.createDummyUser();
+        List<String> imageUrls = List.of("image.com");
+        return Feed.createFeed("피드 제목", "피드 내용", FeedImage.createFeedImages(imageUrls), dummyUser);
+    }
+}

--- a/src/test/java/com/shy_polarbear/server/domain/user/template/UserTemplate.java
+++ b/src/test/java/com/shy_polarbear/server/domain/user/template/UserTemplate.java
@@ -8,17 +8,32 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 public class UserTemplate {
 
     public static final Long ID = 1L;
+    public static final Long OTHER_ID = 2L;
     public static final String NICKNAME = "test";
+    public static final String OTHER_NICKNAME = "test2";
     public static final String EMAIL = "test@naver.com";
+    public static final String OTHER_EMAIL = "test2@naver.com";
     public static final String PROFILE_IMAGE_URL = "2031239.com";
+    public static final String OTHER_PROFILE_IMAGE_URL = "30312391.com";
     public static final String PHONE_NUMBER = "01012341234";
+    public static final String OTHER_PHONE_NUMBER = "01012341235";
     public static final UserRole ROLE = UserRole.ROLE_USR;
+    public static final UserRole OTHER_ROLE = UserRole.ROLE_USR;
     public static final String PROVIDER_ID = "1";
+    public static final String OTHER_PROVIDER_ID = "2";
     public static final ProviderType PROVIDER_TYPE = ProviderType.KAKAO;
     public static final BCryptPasswordEncoder BCRYPT_PASSWORD_ENCODER = new BCryptPasswordEncoder();
 
     public static User createDummyUser() {
-        return User.createUser(NICKNAME, EMAIL, PROFILE_IMAGE_URL, PHONE_NUMBER, ROLE, PROVIDER_ID, PROVIDER_TYPE, BCRYPT_PASSWORD_ENCODER);
+        User user = User.createUser(NICKNAME, EMAIL, PROFILE_IMAGE_URL, PHONE_NUMBER, ROLE, PROVIDER_ID, PROVIDER_TYPE, BCRYPT_PASSWORD_ENCODER);
+        user.setIdForTest(ID);
+        return user;
+    }
+
+    public static User createDummyOtherUserA() {
+        User user = User.createUser(OTHER_NICKNAME, OTHER_EMAIL, OTHER_PROFILE_IMAGE_URL, OTHER_PHONE_NUMBER, OTHER_ROLE, OTHER_PROVIDER_ID, PROVIDER_TYPE, BCRYPT_PASSWORD_ENCODER);
+        user.setIdForTest(OTHER_ID);
+        return user;
     }
 
 }


### PR DESCRIPTION
## 📌 PR 요약
댓글, 대댓글 API 구현 + 테스트

🌱 작업한 내용
- 댓글 리스트 조회 구현
- 댓글 생성, 수정, 삭제(소프트 딜리트), 좋아요 구현
- Repository, Service 테스트 코드

🌱 PR 포인트
- Mock Service 테스트 때문에 이번에도 `setIdForTest` 메서드를 추가했습니다.
- @0sunset0 댓글 좋아요 API 응답을 노션 명세서와 다르게 구현했습니다. 아무래도 like_id는 안 쓰일 것 같아서요! 문제 있다면 수정하겠습니다.
- 댓글 리스트 조회에서 현재 쿼리는 IN 절 (default_batch_size)을 통해 대댓글과 대댓글의 좋아요를 가져옵니다. 그래서 총 3개의 쿼리가  나가게 되는데, 시간이 된다면 추후에 리팩토링하면 좋을듯합니다.

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|

![image](https://github.com/ShyPolarBear/Server/assets/72124326/601210b6-7974-427a-a091-f1fc0a5941e5)
![image](https://github.com/ShyPolarBear/Server/assets/72124326/0e1bccdb-3a93-481f-9932-3d19e3701d9d)
![image](https://github.com/ShyPolarBear/Server/assets/72124326/256cdd45-dd23-4e60-9104-3d5168135d52)
![image](https://github.com/ShyPolarBear/Server/assets/72124326/c9ce45bd-0182-4d23-98f1-901e2b6495c9)
![image](https://github.com/ShyPolarBear/Server/assets/72124326/a5bfef53-70d2-49d4-ba59-cc7789a0b0b2)
![image](https://github.com/ShyPolarBear/Server/assets/72124326/c4727a64-0cd8-4e24-951d-48da37d51cd0)
![image](https://github.com/ShyPolarBear/Server/assets/72124326/ae21787b-7353-42bb-aa46-d937703d385c)


## 📮 관련 이슈
- Resolved: #30 #31 #32 
