### PR TITLE
fix: 피드 이미지 수정 시 버그 해결

### DIFF
--- a/src/main/java/com/shy_polarbear/server/domain/feed/model/Feed.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/model/Feed.java
@@ -32,7 +32,7 @@ public class Feed extends BaseEntity {
     @OneToMany(mappedBy = "feed", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<FeedLike> feedLikes = new ArrayList<>();
     @OneToMany(mappedBy = "feed", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<FeedImage> feedImages;
+    private List<FeedImage> feedImages = new ArrayList<>();
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User author;
@@ -45,7 +45,9 @@ public class Feed extends BaseEntity {
         this.title = title;
         this.content = content;
         this.author = author;
-        this.feedImages = Objects.isNull(feedImages) ? new ArrayList<>() : feedImages;
+        if (!Objects.isNull(feedImages)) {
+            this.feedImages.addAll(feedImages);
+        }
     }
 
     public static Feed createFeed(String title, String content, List<FeedImage> feedImages, User author) {

--- a/src/main/java/com/shy_polarbear/server/domain/user/dto/user/response/UpdateUserInfoResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/user/dto/user/response/UpdateUserInfoResponse.java
@@ -25,7 +25,7 @@ public class UpdateUserInfoResponse {
     public static UpdateUserInfoResponse from(User user) {
         return UpdateUserInfoResponse.builder()
                 .id(user.getId())
-                .nickName(user.getEmail())
+                .nickName(user.getNickName())
                 .profileImage(user.getProfileImage() == null ? "" : user.getProfileImage())
                 .email(user.getEmail())
                 .phoneNumber(user.getPhoneNumber())

--- a/src/main/java/com/shy_polarbear/server/global/common/dto/NoCountPageResponse.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/dto/NoCountPageResponse.java
@@ -9,12 +9,12 @@ import java.util.List;
 @Builder
 @Getter
 public class NoCountPageResponse<T> {   // 무한 스크롤 && 총 개수가 필요없는 클라이언트에 대한 응답 DTO
-    boolean isLast;
+    boolean last;
     List<T> content;
 
     public static <T> NoCountPageResponse<T> of(Slice<T> slice) {  // 오직 Slice. 카운트 쿼리 최적화
         return NoCountPageResponse.<T>builder()
-                .isLast(slice.isLast())
+                .last(slice.isLast())
                 .content(slice.getContent())
                 .build();
     }

--- a/src/main/java/com/shy_polarbear/server/global/common/dto/PageResponse.java
+++ b/src/main/java/com/shy_polarbear/server/global/common/dto/PageResponse.java
@@ -11,13 +11,13 @@ import java.util.List;
 @Getter
 public class PageResponse<T> {  // 총 개수가 필요한 클라이언트에 대한 응답 DTO
     long count;
-    boolean isLast;
+    boolean last;
     List<T> content;
 
     public static <T> PageResponse<T> of(Page<T> page) {
         return PageResponse.<T>builder()
                 .count(page.getTotalElements())
-                .isLast(page.isLast())
+                .last(page.isLast())
                 .content(page.getContent())
                 .build();
     }
@@ -25,7 +25,7 @@ public class PageResponse<T> {  // 총 개수가 필요한 클라이언트에 �
     public static <T> PageResponse<T> of(Slice<T> slice, long totalElements) {  // Slice + 카운트 쿼리
         return PageResponse.<T>builder()
                 .count(totalElements)
-                .isLast(slice.isLast())
+                .last(slice.isLast())
                 .content(slice.getContent())
                 .build();
     }


### PR DESCRIPTION
## 📌 PR 요약

🌱 문제
- 전에 코드 정리를 생각 없이 했는지,, 피드 이미지가 생성자에서 세팅되게 하는 것이 문제가 될 거라고 생각을 못했네요!!
- 생성자에서 피드 이미지를 초기화하면, 피드 이미지는 불변리스트로 초기화되기 때문에 저번과 같은 문제가 발생했습니다.

🌱 해결 방법
-  불변이 아닌 피드 이미지로 초기화 하는 방법도 있지만, 
    - 불변이 안전하기도 하고 
    - 어차피 비어있지 않은 리스트를 갈아끼우면 안되기 때문에 

    빈 리스트에 해당 이미지 값을 추가하게 만들었습니다. 
