### PR TITLE
fix: 스프링 컨텍스트에 있는 객체 사용하게 변경

### DIFF
--- a/spy.log
+++ b/spy.log
@@ -15,3 +15,20 @@
 1694416365611|0|statement|connection 34|url jdbc:h2:mem:bf1e32b7-b24d-4247-addc-6ec86a7fbc99|drop table if exists users CASCADE |drop table if exists users CASCADE 
 1694416365612|0|statement|connection 34|url jdbc:h2:mem:bf1e32b7-b24d-4247-addc-6ec86a7fbc99|drop table if exists withdrawn_user CASCADE |drop table if exists withdrawn_user CASCADE 
 1694416365612|0|statement|connection 34|url jdbc:h2:mem:bf1e32b7-b24d-4247-addc-6ec86a7fbc99|drop sequence if exists hibernate_sequence|drop sequence if exists hibernate_sequence
+1695118706884|1|statement|connection 40|url jdbc:h2:mem:b1a3d106-30cb-4933-b747-b9b8c1d7a585|drop table if exists blocked_user CASCADE |drop table if exists blocked_user CASCADE 
+1695118706886|1|statement|connection 40|url jdbc:h2:mem:b1a3d106-30cb-4933-b747-b9b8c1d7a585|drop table if exists comment CASCADE |drop table if exists comment CASCADE 
+1695118706887|0|statement|connection 40|url jdbc:h2:mem:b1a3d106-30cb-4933-b747-b9b8c1d7a585|drop table if exists comment_like CASCADE |drop table if exists comment_like CASCADE 
+1695118706888|0|statement|connection 40|url jdbc:h2:mem:b1a3d106-30cb-4933-b747-b9b8c1d7a585|drop table if exists dormant_user CASCADE |drop table if exists dormant_user CASCADE 
+1695118706892|4|statement|connection 40|url jdbc:h2:mem:b1a3d106-30cb-4933-b747-b9b8c1d7a585|drop table if exists feed CASCADE |drop table if exists feed CASCADE 
+1695118706894|0|statement|connection 40|url jdbc:h2:mem:b1a3d106-30cb-4933-b747-b9b8c1d7a585|drop table if exists feed_image CASCADE |drop table if exists feed_image CASCADE 
+1695118706894|0|statement|connection 40|url jdbc:h2:mem:b1a3d106-30cb-4933-b747-b9b8c1d7a585|drop table if exists feed_like CASCADE |drop table if exists feed_like CASCADE 
+1695118706895|0|statement|connection 40|url jdbc:h2:mem:b1a3d106-30cb-4933-b747-b9b8c1d7a585|drop table if exists multiple_choice CASCADE |drop table if exists multiple_choice CASCADE 
+1695118706896|0|statement|connection 40|url jdbc:h2:mem:b1a3d106-30cb-4933-b747-b9b8c1d7a585|drop table if exists notification CASCADE |drop table if exists notification CASCADE 
+1695118706897|0|statement|connection 40|url jdbc:h2:mem:b1a3d106-30cb-4933-b747-b9b8c1d7a585|drop table if exists point CASCADE |drop table if exists point CASCADE 
+1695118706897|0|statement|connection 40|url jdbc:h2:mem:b1a3d106-30cb-4933-b747-b9b8c1d7a585|drop table if exists prize CASCADE |drop table if exists prize CASCADE 
+1695118706898|0|statement|connection 40|url jdbc:h2:mem:b1a3d106-30cb-4933-b747-b9b8c1d7a585|drop table if exists quiz CASCADE |drop table if exists quiz CASCADE 
+1695118706898|0|statement|connection 40|url jdbc:h2:mem:b1a3d106-30cb-4933-b747-b9b8c1d7a585|drop table if exists refresh_token CASCADE |drop table if exists refresh_token CASCADE 
+1695118706899|0|statement|connection 40|url jdbc:h2:mem:b1a3d106-30cb-4933-b747-b9b8c1d7a585|drop table if exists user_quiz CASCADE |drop table if exists user_quiz CASCADE 
+1695118706900|0|statement|connection 40|url jdbc:h2:mem:b1a3d106-30cb-4933-b747-b9b8c1d7a585|drop table if exists users CASCADE |drop table if exists users CASCADE 
+1695118706900|0|statement|connection 40|url jdbc:h2:mem:b1a3d106-30cb-4933-b747-b9b8c1d7a585|drop table if exists withdrawn_user CASCADE |drop table if exists withdrawn_user CASCADE 
+1695118706902|0|statement|connection 40|url jdbc:h2:mem:b1a3d106-30cb-4933-b747-b9b8c1d7a585|drop sequence if exists hibernate_sequence|drop sequence if exists hibernate_sequence

--- a/src/main/java/com/shy_polarbear/server/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/controller/FeedController.java
@@ -24,7 +24,7 @@ public class FeedController {
     @PostMapping
     public ApiResponse<CreateFeedResponse> createFeed(@Valid @RequestBody CreateFeedRequest createFeedRequest,
                                                       @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        return ApiResponse.success(feedService.createFeed(createFeedRequest, principalDetails.getUser()));
+        return ApiResponse.success(feedService.createFeed(createFeedRequest, principalDetails.getUser().getId()));
     }
 
     @GetMapping
@@ -32,31 +32,31 @@ public class FeedController {
                                       @RequestParam(required = false) Long lastFeedId,
                                       @RequestParam(required = false, defaultValue = BusinessLogicConstants.FEED_LIMIT_PARAM_DEFAULT_VALUE) int limit,
                                        @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        return ApiResponse.success(feedService.findAllFeeds(sort, lastFeedId, limit, principalDetails.getUser()));
+        return ApiResponse.success(feedService.findAllFeeds(sort, lastFeedId, limit, principalDetails.getUser().getId()));
     }
 
     @GetMapping("/{feedId}")
     public ApiResponse<FeedResponse> findOneFeed(@PathVariable Long feedId,
                                                  @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        return ApiResponse.success(feedService.findFeed(feedId, principalDetails.getUser()));
+        return ApiResponse.success(feedService.findFeed(feedId, principalDetails.getUser().getId()));
     }
 
     @PutMapping("/{feedId}")
     public ApiResponse<UpdateFeedResponse> updateFeed(@PathVariable Long feedId,
                                                       @Valid @RequestBody UpdateFeedRequest updateFeedRequest,
                                                       @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        return ApiResponse.success(feedService.updateFeed(feedId, updateFeedRequest, principalDetails.getUser()));
+        return ApiResponse.success(feedService.updateFeed(feedId, updateFeedRequest, principalDetails.getUser().getId()));
     }
 
     @DeleteMapping("/{feedId}")
     public ApiResponse<DeleteFeedResponse> deleteFeed(@PathVariable Long feedId,
                                                       @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        return ApiResponse.success(feedService.deleteFeed(feedId, principalDetails.getUser()));
+        return ApiResponse.success(feedService.deleteFeed(feedId, principalDetails.getUser().getId()));
     }
 
     @PutMapping("/{feedId}/like")
     public ApiResponse<LikeFeedResponse> switchFeedLike(@PathVariable Long feedId,
                                                         @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        return ApiResponse.success(feedService.switchFeedLike(feedId, principalDetails.getUser()));
+        return ApiResponse.success(feedService.switchFeedLike(feedId, principalDetails.getUser().getId()));
     }
 }

--- a/src/main/java/com/shy_polarbear/server/domain/feed/dto/response/FeedCardResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/dto/response/FeedCardResponse.java
@@ -44,7 +44,7 @@ public class FeedCardResponse {
         private String createdDate;
     }
 
-    public static FeedCardResponse of(Feed feed, Optional<Comment> commentOptional, User user) {
+    public static FeedCardResponse of(Feed feed, Optional<Comment> commentOptional, Long userId) {
         FeedCommentResponse feedCommentResponse;
         if (commentOptional.isPresent()) {
             Comment comment = commentOptional.get();
@@ -55,8 +55,8 @@ public class FeedCardResponse {
                     .authorProfileImage((commentAuthor.getProfileImage() == null) ? "" : commentAuthor.getProfileImage())
                     .content(comment.getContent())
                     .likeCount(comment.getCommentLikes().size())
-                    .isAuthor(comment.isAuthor(user.getId()))
-                    .isLike(comment.isLike(user.getId()))
+                    .isAuthor(comment.isAuthor(userId))
+                    .isLike(comment.isLike(userId))
                     .createdDate(comment.getCreatedDate())
                     .build();
         } else {
@@ -73,8 +73,8 @@ public class FeedCardResponse {
                 .author(feedAuthor.getNickName())
                 .authorProfileImage((feedAuthor.getProfileImage() == null) ? "" : feedAuthor.getProfileImage())
                 .createdDate(feed.getCreatedDate())
-                .isLike(feed.isLike(user))
-                .isAuthor(feed.isAuthor(user))
+                .isLike(feed.isLike(userId))
+                .isAuthor(feed.isAuthor(userId))
                 .commentCount(feed.getComments().size())
                 .comment(feedCommentResponse)
                 .build();

--- a/src/main/java/com/shy_polarbear/server/domain/feed/model/Feed.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/model/Feed.java
@@ -82,13 +82,13 @@ public class Feed extends BaseEntity {
         }
     }
 
-    public boolean isAuthor(User user) {
-        return this.author.getId().equals(user.getId());
+    public boolean isAuthor(Long userId) {
+        return this.author.getId().equals(userId);
     }
 
-    public boolean isLike(User user) {
+    public boolean isLike(Long userId) {
         return feedLikes.stream()
-                .anyMatch(feedLike -> feedLike.isAuthor(user));
+                .anyMatch(feedLike -> feedLike.isAuthor(userId));
     }
 
     public List<String> getFeedImageUrls() {

--- a/src/main/java/com/shy_polarbear/server/domain/feed/model/FeedLike.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/model/FeedLike.java
@@ -40,7 +40,7 @@ public class FeedLike extends BaseEntity {
         return feedLike;
     }
 
-    public boolean isAuthor(User user) {
-        return this.user.getId().equals(user.getId());
+    public boolean isAuthor(Long userId) {
+        return this.user.getId().equals(userId);
     }
 }

--- a/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedLikeRepository.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedLikeRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 
 public interface FeedLikeRepository extends JpaRepository<FeedLike, Long>, FeedLikeRepositoryCustom {
-    void deleteByUserAndFeed(User user, Feed feed);
-    boolean existsByUserAndFeed(User user, Feed feed);
+    void deleteByUserIdAndFeedId(Long userId, Long feedId);
+    boolean existsByUserIdAndFeedId(Long userId, Long feedId);
 
 }

--- a/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedRepository.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedRepository.java
@@ -12,12 +12,12 @@ import java.util.List;
 
 
 public interface FeedRepository extends JpaRepository<Feed, Long>, FeedRepositoryCustom {
-    Slice<Feed> findByIdLessThanAndAuthorOrderByIdDesc(Long id, User author, Pageable pageable);
+    Slice<Feed> findByIdLessThanAndAuthorIdOrderByIdDesc(Long id, Long userId, Pageable pageable);
 
-    Slice<Feed> findByCommentsAuthorAndCommentsIdLessThanOrderByCommentsIdDesc(User author, Long commentId, Pageable pageable);
+    Slice<Feed> findByCommentsAuthorIdAndCommentsIdLessThanOrderByCommentsIdDesc(Long userId, Long commentId, Pageable pageable);
 
-    Slice<Feed> findByAuthorOrderByIdDesc(User author, PageRequest pageable);
+    Slice<Feed> findByAuthorIdOrderByIdDesc(Long userId, PageRequest pageable);
 
-    Slice<Feed> findByCommentsAuthorOrderByCommentsIdDesc(User user, PageRequest pageable);
+    Slice<Feed> findByCommentsAuthorIdOrderByCommentsIdDesc(Long userId, PageRequest pageable);
 
 }

--- a/src/main/java/com/shy_polarbear/server/domain/feed/service/FeedService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/service/FeedService.java
@@ -12,6 +12,7 @@ import com.shy_polarbear.server.domain.feed.repository.FeedLikeRepository;
 import com.shy_polarbear.server.domain.feed.repository.FeedRepository;
 import com.shy_polarbear.server.domain.images.service.ImageService;
 import com.shy_polarbear.server.domain.user.model.User;
+import com.shy_polarbear.server.domain.user.service.UserService;
 import com.shy_polarbear.server.global.common.constants.BusinessLogicConstants;
 import com.shy_polarbear.server.global.common.dto.PageResponse;
 import com.shy_polarbear.server.global.exception.ExceptionStatus;
@@ -34,9 +35,11 @@ public class FeedService {
     private final ImageService imageService;
     private final FeedLikeRepository feedLikeRepository;
     private final CommentRepository commentRepository;
+    private final UserService userService;
     private static DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
-    public CreateFeedResponse createFeed(CreateFeedRequest createFeedRequest, User user) {
+    public CreateFeedResponse createFeed(CreateFeedRequest createFeedRequest, Long userId) {
+        User user = userService.getUser(userId);
         List<String> imageUrls = createFeedRequest.getFeedImages();
         List<FeedImage> feedImages = getFeedImages(imageUrls);
         Feed feed = Feed.createFeed(createFeedRequest.getTitle(), createFeedRequest.getContent(), feedImages, user);
@@ -52,14 +55,14 @@ public class FeedService {
         }
     }
 
-    public FeedResponse findFeed(Long feedId, User user) {
+    public FeedResponse findFeed(Long feedId, Long userId) {
         Feed findFeed = findFeedById(feedId);
-        return FeedResponse.from(findFeed, findFeed.isLike(user), findFeed.isAuthor(user));
+        return FeedResponse.from(findFeed, findFeed.isLike(userId), findFeed.isAuthor(userId));
     }
 
-    public UpdateFeedResponse updateFeed(Long feedId, UpdateFeedRequest updateFeedRequest, User user) {
+    public UpdateFeedResponse updateFeed(Long feedId, UpdateFeedRequest updateFeedRequest, Long userId) {
         Feed findFeed = findFeedById(feedId);
-        checkFeedAuthor(user, findFeed);
+        checkFeedAuthor(userId, findFeed);
         List<FeedImage> feedImages = getFeedImages(updateFeedRequest.getFeedImages());
         findFeed.update(updateFeedRequest.getTitle(), updateFeedRequest.getContent(), feedImages);
         return new UpdateFeedResponse(feedId);
@@ -71,15 +74,15 @@ public class FeedService {
         return findFeed;
     }
 
-    private static void checkFeedAuthor(User user, Feed feed) {
-        if (!feed.isAuthor(user)) {
+    private static void checkFeedAuthor(Long userId, Feed feed) {
+        if (!feed.isAuthor(userId)) {
             throw new FeedException(ExceptionStatus.NOT_MY_FEED);
         }
     }
 
-    public DeleteFeedResponse deleteFeed(Long feedId, User user) {
+    public DeleteFeedResponse deleteFeed(Long feedId, Long userId) {
         Feed findFeed = findFeedById(feedId);
-        checkFeedAuthor(user, findFeed);
+        checkFeedAuthor(userId, findFeed);
         feedRepository.delete(findFeed);
 
         //s3 이미지 삭제
@@ -88,19 +91,20 @@ public class FeedService {
         return new DeleteFeedResponse(feedId);
     }
 
-    public LikeFeedResponse switchFeedLike(Long feedId, User user) {
+    public LikeFeedResponse switchFeedLike(Long feedId, Long userId) {
+        User user = userService.getUser(userId);
         Feed feed = findFeedById(feedId);
-        if (!feedLikeRepository.existsByUserAndFeed(user, feed)) {
+        if (!feedLikeRepository.existsByUserIdAndFeedId(userId, feedId)) {
             FeedLike feedLike = FeedLike.createFeedLike(feed, user);
             feedLikeRepository.save(feedLike);
             return new LikeFeedResponse("좋아요 처리되었습니다.");
         } else {
-            feedLikeRepository.deleteByUserAndFeed(user, feed);
+            feedLikeRepository.deleteByUserIdAndFeedId(userId, feedId);
             return new LikeFeedResponse("좋아요 취소되었습니다.");
         }
     }
 
-    public PageResponse<FeedCardResponse> findAllFeeds(String sort, Long lastFeedId, int limit, User user) {
+    public PageResponse<FeedCardResponse> findAllFeeds(String sort, Long lastFeedId, int limit, Long userId) {
         //정렬 기준에 따라 피드 엔티티 가져오기
         FeedSort feedSort = FeedSort.toEnum(sort);
         Slice<Feed> feeds = null;
@@ -117,7 +121,7 @@ public class FeedService {
         }
 
         // 베스트 댓글 or 최신 댓글 가져오기, DTO로 반환
-        Slice<FeedCardResponse> feedCardResponses = feeds.map(feed -> FeedCardResponse.of(feed, commentRepository.findBestComment(feed), user));
+        Slice<FeedCardResponse> feedCardResponses = feeds.map(feed -> FeedCardResponse.of(feed, commentRepository.findBestComment(feed), userId));
         return PageResponse.of(feedCardResponses, feedCardResponses.stream().count());
     }
 

--- a/src/main/java/com/shy_polarbear/server/domain/user/controller/AuthController.java
+++ b/src/main/java/com/shy_polarbear/server/domain/user/controller/AuthController.java
@@ -37,6 +37,6 @@ public class AuthController {
 
     @PostMapping("/logout")
     public ApiResponse<LogoutResponse> logout(@AuthenticationPrincipal PrincipalDetails principalDetails) {
-        return ApiResponse.success(authService.logOut(principalDetails.getUser()));
+        return ApiResponse.success(authService.logOut(principalDetails.getUser().getId()));
     }
 }

--- a/src/main/java/com/shy_polarbear/server/domain/user/controller/UserController.java
+++ b/src/main/java/com/shy_polarbear/server/domain/user/controller/UserController.java
@@ -25,13 +25,13 @@ public class UserController {
 
     @GetMapping("/me")
     public ApiResponse<UserInfoResponse> findUserInfo(@AuthenticationPrincipal PrincipalDetails principalDetails) {
-        return ApiResponse.success(userService.findUserInfo(principalDetails.getUser()));
+        return ApiResponse.success(userService.findUserInfo(principalDetails.getUser().getId()));
     }
 
     @PutMapping("/me")
     public ApiResponse<UpdateUserInfoResponse> updateUserInfo(@Valid @RequestBody UpdateUserInfoRequest userInfoRequest,
                                                               @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        return ApiResponse.success(userService.updateUserInfo(userInfoRequest, principalDetails.getUser()));
+        return ApiResponse.success(userService.updateUserInfo(userInfoRequest, principalDetails.getUser().getId()));
     }
 
     @GetMapping("/duplicate-nickname")
@@ -45,9 +45,9 @@ public class UserController {
                                                            @AuthenticationPrincipal PrincipalDetails principalDetails) {
         limit = (limit == null) ? 10 : limit;
         if (lastFeedId == null) {
-            return ApiResponse.success(userService.findUserFeeds(limit, principalDetails.getUser()));
+            return ApiResponse.success(userService.findUserFeeds(limit, principalDetails.getUser().getId()));
         }
-        return ApiResponse.success(userService.findUserFeedsByCursorId(lastFeedId, limit, principalDetails.getUser()));
+        return ApiResponse.success(userService.findUserFeedsByCursorId(lastFeedId, limit, principalDetails.getUser().getId()));
     }
 
     @GetMapping("/comments/feeds")
@@ -56,8 +56,8 @@ public class UserController {
                                                                            @AuthenticationPrincipal PrincipalDetails principalDetails) {
         limit = (limit == null) ? 10 : limit;
         if (lastCommentId == null) {
-            return ApiResponse.success(userService.findUserCommentFeeds(limit, principalDetails.getUser()));
+            return ApiResponse.success(userService.findUserCommentFeeds(limit, principalDetails.getUser().getId()));
         }
-        return ApiResponse.success(userService.findUserCommentFeedsByCursorId(lastCommentId, limit, principalDetails.getUser()));
+        return ApiResponse.success(userService.findUserCommentFeedsByCursorId(lastCommentId, limit, principalDetails.getUser().getId()));
     }
 }

--- a/src/main/java/com/shy_polarbear/server/domain/user/dto/user/response/UserCommentFeedsResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/user/dto/user/response/UserCommentFeedsResponse.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 public class UserCommentFeedsResponse {
     private Integer count;
-    private Boolean isLast;
+    private Boolean last;
     private List<UserFeedResponse> content;
 
     @AllArgsConstructor
@@ -40,9 +40,9 @@ public class UserCommentFeedsResponse {
     }
 
     @Builder
-    public UserCommentFeedsResponse(Boolean isLast, List<Feed> feedList) {
+    public UserCommentFeedsResponse(Boolean last, List<Feed> feedList) {
         this.count = feedList.size();
-        this.isLast = isLast;
+        this.last = last;
         this.content = feedList.stream()
                 .map((feed -> UserFeedResponse.from(feed)))
                 .collect(Collectors.toList());

--- a/src/main/java/com/shy_polarbear/server/domain/user/dto/user/response/UserFeedsResponse.java
+++ b/src/main/java/com/shy_polarbear/server/domain/user/dto/user/response/UserFeedsResponse.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 public class UserFeedsResponse {
     private Integer count;
-    private Boolean isLast;
+    private Boolean last;
     private List<UserFeedResponse> content;
 
     @AllArgsConstructor
@@ -33,9 +33,9 @@ public class UserFeedsResponse {
     }
 
     @Builder
-    public UserFeedsResponse(Boolean isLast, List<Feed> feedList) {
+    public UserFeedsResponse(Boolean last, List<Feed> feedList) {
         this.count = feedList.size();
-        this.isLast = isLast;
+        this.last = last;
         this.content = feedList.stream()
                 .map((feed -> UserFeedResponse.from(feed)))
                 .collect(Collectors.toList());

--- a/src/main/java/com/shy_polarbear/server/domain/user/service/AuthService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/user/service/AuthService.java
@@ -92,8 +92,8 @@ public class AuthService {
     }
 
     // refresh token 삭제하는 방식 사용
-    public LogoutResponse logOut(User user) {
-        RefreshToken refreshToken = refreshTokenRepository.findByUser(user)
+    public LogoutResponse logOut(Long userId) {
+        RefreshToken refreshToken = refreshTokenRepository.findByUserId(userId)
                 .orElseThrow(() -> new AuthException(ExceptionStatus.INVALID_REFRESH_TOKEN));
         refreshTokenRepository.delete(refreshToken);
         refreshTokenRepository.flush();

--- a/src/main/java/com/shy_polarbear/server/domain/user/service/UserService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/user/service/UserService.java
@@ -44,11 +44,13 @@ public class UserService {
         return user.getId();
     }
 
-    public UserInfoResponse findUserInfo(User user) {
+    public UserInfoResponse findUserInfo(Long userId) {
+        User user = getUser(userId);
         return UserInfoResponse.from(user);
     }
 
-    public UpdateUserInfoResponse updateUserInfo(UpdateUserInfoRequest userInfoRequest, User user) {
+    public UpdateUserInfoResponse updateUserInfo(UpdateUserInfoRequest userInfoRequest, Long userId) {
+        User user = getUser(userId);
         if (!user.isSameNickName(userInfoRequest.getNickName())) {
             checkDuplicateNickName(userInfoRequest.getNickName());
         }
@@ -60,36 +62,36 @@ public class UserService {
         return userRepository.findById(userId).orElseThrow(() -> new UserException(ExceptionStatus.NOT_FOUND_USER));
     }
 
-    public UserFeedsResponse findUserFeedsByCursorId(Long lastFeedId, Integer limit, User user) {
-        Slice<Feed> findFeedList = feedRepository.findByIdLessThanAndAuthorOrderByIdDesc(lastFeedId, user, PageRequest.of(0, limit));
+    public UserFeedsResponse findUserFeedsByCursorId(Long lastFeedId, Integer limit, Long userId) {
+        Slice<Feed> findFeedList = feedRepository.findByIdLessThanAndAuthorIdOrderByIdDesc(lastFeedId, userId, PageRequest.of(0, limit));
         return getUserFeedsResponse(findFeedList);
     }
 
-    public UserFeedsResponse findUserFeeds(Integer limit, User user) {
-        Slice<Feed> findFeedList = feedRepository.findByAuthorOrderByIdDesc(user, PageRequest.of(0, limit));
+    public UserFeedsResponse findUserFeeds(Integer limit, Long userId) {
+        Slice<Feed> findFeedList = feedRepository.findByAuthorIdOrderByIdDesc(userId, PageRequest.of(0, limit));
         return getUserFeedsResponse(findFeedList);
     }
 
-    public UserCommentFeedsResponse findUserCommentFeedsByCursorId(Long lastCommentId, Integer limit, User user) {
-        Slice<Feed> findFeedList = feedRepository.findByCommentsAuthorAndCommentsIdLessThanOrderByCommentsIdDesc(user, lastCommentId, PageRequest.of(0, limit));
+    public UserCommentFeedsResponse findUserCommentFeedsByCursorId(Long lastCommentId, Integer limit, Long userId) {
+        Slice<Feed> findFeedList = feedRepository.findByCommentsAuthorIdAndCommentsIdLessThanOrderByCommentsIdDesc(userId, lastCommentId, PageRequest.of(0, limit));
         return getUserCommentFeedsResponse(findFeedList);
     }
 
-    public UserCommentFeedsResponse findUserCommentFeeds(Integer limit, User user) {
-        Slice<Feed> findFeedList = feedRepository.findByCommentsAuthorOrderByCommentsIdDesc(user, PageRequest.of(0, limit));
+    public UserCommentFeedsResponse findUserCommentFeeds(Integer limit, Long userId) {
+        Slice<Feed> findFeedList = feedRepository.findByCommentsAuthorIdOrderByCommentsIdDesc(userId, PageRequest.of(0, limit));
         return getUserCommentFeedsResponse(findFeedList);
     }
 
     private static UserFeedsResponse getUserFeedsResponse(Slice<Feed> findFeedList) {
         return UserFeedsResponse.builder()
-                .isLast(findFeedList.isLast())
+                .last(findFeedList.isLast())
                 .feedList(findFeedList.stream().toList())
                 .build();
     }
 
     private static UserCommentFeedsResponse getUserCommentFeedsResponse(Slice<Feed> findFeedList) {
         return UserCommentFeedsResponse.builder()
-                .isLast(findFeedList.isLast())
+                .last(findFeedList.isLast())
                 .feedList(findFeedList.stream().toList())
                 .build();
     }

--- a/src/main/java/com/shy_polarbear/server/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/shy_polarbear/server/global/auth/jwt/JwtProvider.java
@@ -116,7 +116,7 @@ public class JwtProvider {
     public JwtDto issue(User user) {
         String accessToken = createAccessToken(user);
         String refreshToken = createRefreshToken(user);
-        Optional<RefreshToken> findRefreshToken = refreshTokenRepository.findByUser(user);
+        Optional<RefreshToken> findRefreshToken = refreshTokenRepository.findByUserId(user.getId());
         if (findRefreshToken.isPresent()) {
             findRefreshToken.get().replace(refreshToken);
         } else {

--- a/src/main/java/com/shy_polarbear/server/global/auth/jwt/RefreshTokenRepository.java
+++ b/src/main/java/com/shy_polarbear/server/global/auth/jwt/RefreshTokenRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
-    Optional<RefreshToken> findByUser(User user);
+    Optional<RefreshToken> findByUserId(Long userId);
 }

--- a/src/test/java/com/shy_polarbear/server/domain/feed/service/FeedServiceTest.java
+++ b/src/test/java/com/shy_polarbear/server/domain/feed/service/FeedServiceTest.java
@@ -67,14 +67,14 @@ class FeedServiceTest {
     @Test
     void createFeed() {
         CreateFeedRequest createFeedRequest = new CreateFeedRequest("111", "111", imageUrls);
-        CreateFeedResponse createFeedResponse = feedService.createFeed(createFeedRequest, user);
+        CreateFeedResponse createFeedResponse = feedService.createFeed(createFeedRequest, user.getId());
         assertThat(createFeedResponse.getFeedId()).isNotNull();
     }
 
     @DisplayName("findFeed()메서드는 피드가 존재하지 않는다면 FeedException을 던진다.")
     @Test
     void findFeed_exception() {
-        assertThatThrownBy( () -> feedService.findFeed(-1L, user))
+        assertThatThrownBy( () -> feedService.findFeed(-1L, user.getId()))
                 .isInstanceOf(FeedException.class)
                 .hasMessage(ExceptionStatus.NOT_FOUND_FEED.getMessage());
     }
@@ -82,7 +82,7 @@ class FeedServiceTest {
     @DisplayName("findFeed()메서드는 피드가 존재하면 FeedResponse를 리턴한다.")
     @Test
     void findFeed() {
-        FeedResponse feedResponse = feedService.findFeed(saveFeed.getId(), user);
+        FeedResponse feedResponse = feedService.findFeed(saveFeed.getId(), user.getId());
         assertThat(feedResponse.getFeedId()).isEqualTo(saveFeed.getId());
     }
 
@@ -91,7 +91,7 @@ class FeedServiceTest {
     @Test
     void updateFeed() {
         UpdateFeedRequest updateFeedRequest = new UpdateFeedRequest("수정 제목", "수정 내용", null);
-        feedService.updateFeed(saveFeed.getId(), updateFeedRequest, user);
+        feedService.updateFeed(saveFeed.getId(), updateFeedRequest, user.getId());
         Feed feed = feedRepository.findById(saveFeed.getId()).get();
         assertThat(feed.getTitle()).isEqualTo("수정 제목");
     }
@@ -100,7 +100,7 @@ class FeedServiceTest {
     @Test
     void updateFeed_exception() {
         UpdateFeedRequest updateFeedRequest = new UpdateFeedRequest("수정 제목", "수정 내용", null);
-        assertThatThrownBy(() -> feedService.updateFeed(saveFeed.getId(), updateFeedRequest, anotherUser))
+        assertThatThrownBy(() -> feedService.updateFeed(saveFeed.getId(), updateFeedRequest, anotherUser.getId()))
                 .isInstanceOf(FeedException.class)
                 .hasMessage(ExceptionStatus.NOT_MY_FEED.getMessage());
     }
@@ -108,15 +108,15 @@ class FeedServiceTest {
     @DisplayName("switchFeedLike()는 좋아요 취소 상태에서 좋아요를 실행한다.")
     @Test
     void switchFeedLike_like() {
-        LikeFeedResponse likeFeedResponse = feedService.switchFeedLike(saveFeed.getId(), user);
+        LikeFeedResponse likeFeedResponse = feedService.switchFeedLike(saveFeed.getId(), user.getId());
         assertThat(likeFeedResponse.getResult()).isEqualTo("좋아요 처리되었습니다.");
     }
 
     @DisplayName("switchFeedLike()는 좋아요 상태에서 좋아요 취소를 실행한다.")
     @Test
     void switchFeedLike_cancel() {
-        feedService.switchFeedLike(saveFeed.getId(), user);
-        LikeFeedResponse likeFeedResponse = feedService.switchFeedLike(saveFeed.getId(), user);
+        feedService.switchFeedLike(saveFeed.getId(), user.getId());
+        LikeFeedResponse likeFeedResponse = feedService.switchFeedLike(saveFeed.getId(), user.getId());
         assertThat(likeFeedResponse.getResult()).isEqualTo("좋아요 취소되었습니다.");
     }
 }

--- a/src/test/java/com/shy_polarbear/server/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/shy_polarbear/server/domain/user/service/UserServiceTest.java
@@ -80,7 +80,7 @@ class UserServiceTest {
     @DisplayName("findUserInfo() 메서드는 유저의 정보를 반환한다.")
     @Test
     void findUserInfo() {
-        UserInfoResponse userInfo = userService.findUserInfo(user1);
+        UserInfoResponse userInfo = userService.findUserInfo(user1.getId());
         Assertions.assertThat(userInfo.getEmail()).isEqualTo(user1.getEmail());
         Assertions.assertThat(userInfo.getNickName()).isEqualTo(user1.getNickName());
         Assertions.assertThat(userInfo.getPhoneNumber()).isEqualTo(user1.getPhoneNumber());


### PR DESCRIPTION
## 📌 PR 요약

🌱 이슈
![image](https://github.com/ShyPolarBear/Server/assets/81086966/21897eb0-80df-4722-9801-a39c97456237)

- `@AuthenticationPrincipal PrincipalDetails principalDetails`로 가져오는 객체는, 스프링 시큐리티의 세션 객체 저장소인 SecurityContextHolder의 **세션영역 SecurityContext**에 저장되어 있는 인증객체입니다. 따라서 영속성 컨텍스트가 관리하는 객체가 아니라 변경감지가 일어나지 않습니다!! (유저 정보 수정 요청 시 수정이 되지 않는 문제 발생)


🌱 해결
- controller에서 userId만 넘기고, service에서 user을 찾아오게 변경했습니다.
- 추가로, 데이터를 가져올 때 엔티티 말고 엔티티의 id로 넘기게 변경하였습니다. 


세션에 있는 객체는 스프링이 관리하지 않고 db에 있는 데이터랑 다를 가능성도 있는 객체인데 
생각없이 개발을 해서 생긴 문제였습니다,,,
