### PR TITLE
fix: 코멘트 조회 쿼리문 조인 오류

### DIFF
--- a/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryImpl.java
@@ -42,9 +42,9 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
     public Slice<Comment> findAllParentComment(long currentUserId, long feedId, Long cursorId, int limit) {
         JPAQuery<Comment> query = queryFactory
                 .selectFrom(comment)
-                .leftJoin(comment.author, user).fetchJoin()
-                .leftJoin(comment.feed, feed).fetchJoin()
-                .join(comment.commentLikes, commentLike).fetchJoin()
+                .join(comment.author, user).fetchJoin()
+                .join(comment.feed, feed).fetchJoin()
+                .leftJoin(comment.commentLikes, commentLike)
                 .where(eqFeedId(feedId).and(gtCursorId(cursorId))
                         .and(comment.parent.isNull()))
                 .orderBy(comment.id.asc())  // 오래된 순


### PR DESCRIPTION
## 📌 PR 요약
코멘트 조회 쿼리문 조인 오류

🌱 작업한 내용
- 부모 엔티티를 left join ->  join
- 자식 엔티티를 join -> left join

왜 이 둘을 반대로 썼을까요..? :upside_down_face:  

🌱 PR 포인트
-

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|

## 📮 관련 이슈
- Resolved: #이슈번호
