### PR TITLE
fix: 피드 베스트 댓글 삭제 댓글이 조회되는 문제 해결

### DIFF
--- a/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryImpl.java
@@ -29,7 +29,10 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
     public Optional<Comment> findBestComment(Feed feed) {
         JPAQuery<Comment> query = queryFactory
                 .selectFrom(comment)
-                .where(checkFeed(feed))
+                .where(
+                        checkFeed(feed),
+                        comment.visibility.eq(true)
+                )
                 .orderBy(
                         comment.commentLikes.size().desc(),
                         comment.createdDate.desc()
@@ -75,6 +78,7 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                 .from(comment)
                 .where(
                         comment.author.id.eq(userId),
+                        comment.visibility.eq(true),
                         ltCursorId(lastCommentId)
                 )
                 .groupBy(comment.feed.id));


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 전체 피드 조회 : 베스트 댓글 조회 시 삭제 된 댓글이어도 조회되는 문제
- 내가 댓글을 작성한 피드 조회 : 내가 삭제한 댓글의 피드도 가져오는 문제

where 조건 하나 추가했습니다~!
