### PR TITLE
fix: 일대다 join문에 distinct 추가

### DIFF
--- a/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryImpl.java
@@ -51,7 +51,8 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
                 .where(eqFeedId(feedId).and(gtCursorId(cursorId))
                         .and(comment.parent.isNull()))
                 .orderBy(comment.id.asc())  // 오래된 순
-                .limit(CustomSliceExecutionUtils.buildSliceLimit(limit));
+                .limit(CustomSliceExecutionUtils.buildSliceLimit(limit))
+                .distinct();
 
         return CustomSliceExecutionUtils.getSlice(query.fetch(), limit);
     }


### PR DESCRIPTION
## 📌 PR 요약
이전에 일대다 fetch join을 제거하는 과정에서 DISTINCT문을 생략해서 발생한 문제였습니다..!

fetch join을 제거했던 이유는 올려주신 이슈처럼 일대다 fetch join과 limit을 같이 쓸 때 조인 결과가 틀리게 나올 수 있어서였어요 + 메모리 이슈

근데 이걸 제거하니 DB에선 연관관계 엔티티들을 싹 다 가져오게 되고, 
com1 - like1
com1 - like2
com1 - like3
com1 - ...

이런 식으로 객체가 중복되더라구요...!

🌱 작업한 내용
- distinct 추가

🌱 PR 포인트
- 졸업 전시전에 미리 못 고쳐서 죄송해요 :sob: 글고 신경써주셔서 정말 감사합니다 
- 노을님께서 쿼리문들에서 일대다 fetch join을 쓰신 부분이 있는데 요 부분 수정하시면 더 좋을것 같아요 :+1: 

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|

## 📮 관련 이슈
- Resolved: #87 
