### PR TITLE
refactor: distinct 키워드 추가

### DIFF
--- a/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryCustom.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryCustom.java
@@ -12,5 +12,5 @@ public interface CommentRepositoryCustom {
 
     Slice<Comment> findAllParentComment(long currentUserId, long feedId, Long cursorId, int limit);
 
-    Slice<Comment> findRecentUserCommentsInFeed(Long lastCommentId, Integer limit, Long userId);
+    Slice<Comment> findRecentAllUserCommentsInFeed(Long lastCommentId, Integer limit, Long userId);
 }

--- a/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/shy_polarbear/server/domain/comment/repository/CommentRepositoryImpl.java
@@ -57,17 +57,19 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
     }
 
     @Override
-    public Slice<Comment> findRecentUserCommentsInFeed(Long lastCommentId, Integer limit, Long userId) {
+    public Slice<Comment> findRecentAllUserCommentsInFeed(Long lastCommentId, Integer limit, Long userId) {
         JPAQuery<Comment> query = queryFactory
                 .selectFrom(comment)
                 .join(comment.feed, feed).fetchJoin()
                 .join(feed.author, user).fetchJoin()
-                .leftJoin(feed.feedImages, feedImage).fetchJoin()
+                .leftJoin(feed.feedImages, feedImage)
                 .where(
                         findRecentUserCommentIdsInFeed(lastCommentId, userId)
                 )
                 .orderBy(comment.id.desc())
-                .limit(CustomSliceExecutionUtils.buildSliceLimit(limit));//fetch join -> 애플리케이션 단에서 limit
+                .limit(CustomSliceExecutionUtils.buildSliceLimit(limit)) //fetch join -> 애플리케이션 단에서 limit
+                .distinct();
+
 
         return CustomSliceExecutionUtils.getSlice(query.fetch(), limit);
     }

--- a/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedRepositoryImpl.java
+++ b/src/main/java/com/shy_polarbear/server/domain/feed/repository/FeedRepositoryImpl.java
@@ -71,13 +71,14 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
     public Slice<Feed> findUserFeeds(Long lastFeedId, int limit, Long userId) {
         JPAQuery<Feed> query = queryFactory
                 .selectFrom(feed)
-                .leftJoin(feed.feedImages, feedImage).fetchJoin()
+                .leftJoin(feed.feedImages, feedImage)
                 .where(
                         feed.author.id.eq(userId),
                         lessThanLastFeedId(lastFeedId)
                 )
                 .orderBy(feed.id.desc())
-                .limit(CustomSliceExecutionUtils.buildSliceLimit(limit));
+                .limit(CustomSliceExecutionUtils.buildSliceLimit(limit))
+                .distinct();
         return CustomSliceExecutionUtils.getSlice(query.fetch(), limit);
     }
 

--- a/src/main/java/com/shy_polarbear/server/domain/user/service/UserService.java
+++ b/src/main/java/com/shy_polarbear/server/domain/user/service/UserService.java
@@ -76,7 +76,7 @@ public class UserService {
     }
 
     public PageResponse<UserCommentFeedResponse> findAllFeedsByUserComment(Long lastCommentId, Integer limit, Long userId) {
-        Slice<Comment> userCommentsInFeed = commentRepository.findRecentUserCommentsInFeed(lastCommentId, limit, userId);
+        Slice<Comment> userCommentsInFeed = commentRepository.findRecentAllUserCommentsInFeed(lastCommentId, limit, userId);
         Slice<UserCommentFeedResponse> userCommentFeedResponses = userCommentsInFeed
                 .map(comment -> UserCommentFeedResponse.from(comment.getFeed(), comment.getId()));
         return PageResponse.of(userCommentFeedResponses, userCommentFeedResponses.stream().count());


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 피드, 피드 이미지 일대다 관계에서 
메모리 `fetch join+limit`이 아니라 `distinct`로 중복 없앴습니다